### PR TITLE
/blog/* -> /blog/posts/*

### DIFF
--- a/components/PostList.tsx
+++ b/components/PostList.tsx
@@ -27,7 +27,7 @@ export const PostList: React.FC<PostListProps> = ({ posts }) => {
         >
           <Box paddingY="1rem">
             <Link
-              href={`/blog/${slug}`}
+              href={`/blog/posts/${slug}`}
               color="black"
               display="block"
               _hover={{ outline: 'none' }}

--- a/pages/blog/posts/[slug].tsx
+++ b/pages/blog/posts/[slug].tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
 import { GetStaticPaths, GetStaticProps } from 'next'
 import { getMDXComponent } from 'mdx-bundler/client'
-import { getAllPosts, getSinglePost } from '../../utils/mdx'
+import { getAllPosts, getSinglePost } from '../../../utils/mdx'
 import { ParsedUrlQuery } from 'node:querystring'
-import { MDXLayout } from '../../components/MDXLayout'
-import { mdxComponents } from '../../components/mdx'
+import { MDXLayout } from '../../../components/MDXLayout'
+import { mdxComponents } from '../../../components/mdx'
 
 interface Props extends Awaited<ReturnType<typeof getSinglePost>> {}
 


### PR DESCRIPTION
## Why

- 後方互換性維持のため
  - もともと blog.fohte.net/posts/* だったのでそれに合わせる (リダイレクトの設定も面倒そうなので)