### PR TITLE
automerge @types

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -8,5 +8,10 @@
       matchUpdateTypes: ['patch'],
       automerge: true,
     },
+    {
+      matchPackagePatterns: ['^@types/'],
+      matchUpdateTypes: ['patch'],
+      automerge: true,
+    },
   ],
 }


### PR DESCRIPTION
#51 で良いと思っていたが、`@types/react` などは react monorepo にまとめられるからか devDependencies 扱いになっておらず automerge が有効にできていなかった。
`@types` も個別に automerge 設定を入れる。