### PR TITLE
renovate: enable lockFileMaintenance on 5:00 Sat JST

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,11 @@
 {
   extends: ['config:base'],
   configMigration: true,
+  timezone: 'Asia/Tokyo',
+  lockFileMaintenance: {
+    enabled: true,
+    schedule: 'before 5am on Saturday',
+  },
 
   packageRules: [
     {


### PR DESCRIPTION
依存の依存パッケージの更新を定期的にやったほうが良い。
package.json でバージョン管理するほどでもないので Renovate で定期的に lockfile を更新する。