### PR TITLE
test envvars by cloudflare pages for debug

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,4 +6,12 @@ const nextConfig = {
   output: 'export',
 }
 
+console.log('[DEBUG] cloudflare pages env', {
+  CF_PAGES: process.env.CF_PAGES,
+  CF_PAGES_COMMIT_SHA: process.env.CF_PAGES_COMMIT_SHA,
+  CF_PAGES_BRANCH: process.env.CF_PAGES_BRANCH,
+  CF_PAGES_URL: process.env.CF_PAGES_URL,
+  NODE_ENV: process.env.NODE_ENV,
+})
+
 module.exports = withContentlayer(nextConfig)


### PR DESCRIPTION
[Build configuration · Cloudflare Pages docs](https://developers.cloudflare.com/pages/configuration/build-configuration/)


> Environment Variable | Injected value | Example use-case
> -- | -- | --
> CF_PAGES | 1 | Changing build behaviour when run on Pages versus locally
> CF_PAGES_COMMIT_SHA | `<sha1-hash-of-current-commit>` | Passing current commit ID to error reporting, for example, Sentry
> CF_PAGES_BRANCH | `<branch-name-of-current-deployment>` | Customizing build based on branch, for example, disabling debug logging on production
> CF_PAGES_URL | `<url-of-current-deployment>` | Allowing build tools to know the URL the page will be deployed at
> 
