### PR TITLE
ci: switch to commit-action for secure auto-formatting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ name: Test
 on:
   push:
 
+permissions:
+  contents: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -16,23 +19,17 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
       - uses: oven-sh/setup-bun@v1
       - uses: reviewdog/action-setup@v1
       - run: bun install --frozen-lockfile
       - run: bun run format
 
-      - id: files-formatted
-        run: |
-          echo "formatted=$(git diff-index --quiet HEAD && echo false || echo true)" >> "$GITHUB_OUTPUT"
-
-      - name: commit formatted files
-        run: |
-          git config user.email '139195068+fohte-bot[bot]@users.noreply.github.com'
-          git config user.name 'fohte-bot[bot]'
-          git add .
-          git commit -m 'style: $ bun run format'
-          git push
-        if: steps.files-formatted.outputs.formatted == 'true'
+      - name: Commit formatted files
+        uses: suzuki-shunsuke/commit-action@v0.0.7
+        with:
+          commit_message: 'style: auto-format'
+          workflow: deny
+          github_token: ${{ steps.app-token.outputs.token }}
 
       - run: bun run test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # blog.fohte.net
 
-@fohte の個人用ブログ ([blog.fohte.net](https://blog.fohte.net)) のリポジトリです。   
+@fohte の個人用ブログ ([blog.fohte.net](https://blog.fohte.net)) のリポジトリです。
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # blog.fohte.net
 
-@fohte の個人用ブログ ([blog.fohte.net](https://blog.fohte.net)) のリポジトリです。
+@fohte の個人用ブログ ([blog.fohte.net](https://blog.fohte.net)) のリポジトリです。   
 
 ## License
 


### PR DESCRIPTION
## Why

- Direct git operations in CI workflows create security vulnerabilities through RCE attack vectors
- Git hooks, filters, and extensions can execute arbitrary code during git operations
- Need to eliminate dependency on local git command execution for automated commits

## What

- Replace direct git operations with commit-action that uses GitHub API instead of git commands
- Add workflow modification protection with workflow: deny setting
- Remove persist-credentials from checkout to prevent token leakage
- Limit workflow permissions to contents: write only