### PR TITLE
chore: migrate bun version management to mise

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Setup mise
+        uses: jdx/mise-action@v2
         with:
-          bun-version: latest
+          install: true
 
       - name: Cache dependencies
         uses: actions/cache@v4

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -9,7 +9,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v1
+      - name: Setup mise
+        uses: jdx/mise-action@v2
+        with:
+          install: true
       - uses: reviewdog/action-setup@v1
       - run: bun install --frozen-lockfile
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: oven-sh/setup-bun@v1
+      - name: Setup mise
+        uses: jdx/mise-action@v2
+        with:
+          install: true
       - uses: reviewdog/action-setup@v1
       - run: bun install --frozen-lockfile
       - run: bun run format

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+[tools]
+bun = "1.2.15"
+
+[env]
+# Environment variables can be defined here if needed


### PR DESCRIPTION
## Why

- Version management is currently not consistent - CI uses `latest` bun version while developers might have different versions
- Need reproducible builds across all environments
- mise provides a unified solution for managing tool versions (following the same pattern as https://github.com/fohte/tasker/pull/9)

## What

- Add `mise.toml` with pinned bun version **1.2.15**
- Update GitHub Actions workflows to use `mise-action` instead of separate bun setup
- Centralize version management in a single configuration file

🤖 Generated with [Claude Code](https://claude.ai/code)