### PR TITLE
fix: Percy VRT tests 404 error and filter test posts correctly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,5 +78,5 @@ jobs:
       - name: Run Percy VRT
         run: bun run test:vrt
         env:
-          NODE_ENV: test
+          APP_ENV: test
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/percy.config.js
+++ b/percy.config.js
@@ -10,7 +10,7 @@ module.exports = {
   },
   percy: {
     env: {
-      NODE_ENV: 'test',
+      APP_ENV: 'test',
     },
   },
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -44,7 +44,7 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
     env: {
-      NODE_ENV: 'test',
+      APP_ENV: 'test',
     },
   },
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -39,10 +39,13 @@ export default defineConfig({
 
   // Run local dev server before starting the tests
   webServer: {
-    command: 'bun run dev',
+    command: 'NODE_ENV=test bun run dev',
     port: 3000,
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
+    env: {
+      NODE_ENV: 'test',
+    },
   },
 
   // Retry failed tests

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
 
   // Run local dev server before starting the tests
   webServer: {
-    command: 'NODE_ENV=test bun run dev',
+    command: 'bun run dev',
     port: 3000,
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,

--- a/src/app/test/blog/page.tsx
+++ b/src/app/test/blog/page.tsx
@@ -9,7 +9,7 @@ import { findPostFrontmatter } from '@/utils/contentlayer'
 
 export default async function TestBlogListPage() {
   // テスト環境以外では404を返す
-  if (process.env.NODE_ENV !== 'test') {
+  if (process.env.APP_ENV !== 'test') {
     notFound()
   }
 

--- a/src/app/test/blog/page.tsx
+++ b/src/app/test/blog/page.tsx
@@ -13,11 +13,13 @@ export default async function TestBlogListPage() {
     notFound()
   }
 
-  // VRTテスト用記事を表示（テスト環境では自動的にフィルタリング済み）
-  const vrtTestPosts = allPosts.map((post) => ({
-    slug: post._raw.flattenedPath,
-    frontmatter: findPostFrontmatter(post),
-  }))
+  // VRTテスト用記事のみを表示
+  const vrtTestPosts = allPosts
+    .filter((post) => post._raw.flattenedPath.includes('vrt-test-'))
+    .map((post) => ({
+      slug: post._raw.flattenedPath,
+      frontmatter: findPostFrontmatter(post),
+    }))
 
   return (
     <Container backgroundColor="white">

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -12,6 +12,11 @@ const getEnv = (): 'production' | 'preview' | 'development' | 'test' => {
     return 'preview'
   }
 
+  // APP_ENV takes precedence for test environment
+  if (process.env.APP_ENV === 'test') {
+    return 'test'
+  }
+
   if (
     process.env.NODE_ENV === 'production' ||
     process.env.NODE_ENV === 'development' ||


### PR DESCRIPTION
## Why

- Percy visual regression tests were returning 404 errors for the `/test/blog` page
- This issue was present since VRT was introduced in #358
- The page was checking `NODE_ENV === 'test'`, but Next.js forces `NODE_ENV=development` when using `next dev`
- Additionally, the test blog page was showing all posts instead of only VRT test posts

## What

- Replace `NODE_ENV` checks with `APP_ENV=test` for test environment detection
- Update all configurations (Playwright, Percy, CI) to use `APP_ENV` instead of `NODE_ENV`
- Add filtering to test blog page to only show posts with 'vrt-test-' in their path
- Percy tests can now correctly capture snapshots of test-specific pages with only test content