### PR TITLE
chore: configure Percy to use Chrome browser only

### DIFF
--- a/percy.config.js
+++ b/percy.config.js
@@ -7,6 +7,7 @@ module.exports = {
     widths: [375, 1200], // Mobile first, then desktop
     minHeight: 1024,
     percyCSS: '',
+    browsers: ['chrome'],
   },
   percy: {
     env: {


### PR DESCRIPTION
## Why

- Configure Percy to use Chrome browser only to reduce snapshot count
- Reducing from 4 browsers (Chrome, Firefox, Safari, Edge) to Chrome only reduces snapshot count by 75%

## What

- Disabled Firefox, Safari, and Edge in Percy dashboard settings, keeping only Chrome enabled
- This reduces visual regression testing costs