### PR TITLE
Disable Google Analytics in non-production environments

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -6,6 +6,7 @@ import { css, Global } from '@emotion/react'
 
 import { GoogleAnalytics } from '@/components/GoogleAnalytics'
 import { theme } from '@/styles/theme'
+import { env } from '@/utils/config'
 
 const globalStyles = css`
   // hack to fix footer to the bottom
@@ -59,7 +60,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
         </ChakraProvider>
       </CacheProvider>
 
-      <GoogleAnalytics />
+      {env === 'production' && <GoogleAnalytics />}
     </>
   )
 }


### PR DESCRIPTION
## Why

- Google Analytics should only track production usage to avoid contaminating analytics data with development, preview, and test traffic
- This prevents unnecessary tracking and improves privacy during development

## What

- Google Analytics component only renders when `env === 'production'`
- Analytics tracking is disabled in development, preview, and test environments

🤖 Generated with [Claude Code](https://claude.ai/code)