### PR TITLE
Fix preview env detection by using NEXT_PUBLIC_APP_ENV instead of runtime variables

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,9 +58,7 @@ jobs:
             ${{ runner.os }}-nextjs-
 
       - name: Build
-        run: bun run build
-        env:
-          APP_ENV: ${{ github.ref == 'refs/heads/master' && 'production' || 'preview' }}
+        run: APP_ENV=${{ github.ref == 'refs/heads/master' && 'production' || 'preview' }} bun run build
 
       - name: Deploy to Cloudflare Pages
         id: cloudflare-deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
             ${{ runner.os }}-nextjs-
 
       - name: Build
-        run: APP_ENV=${{ github.ref == 'refs/heads/master' && 'production' || 'preview' }} bun run build
+        run: NEXT_PUBLIC_APP_ENV=${{ github.ref == 'refs/heads/master' && 'production' || 'preview' }} APP_ENV=${{ github.ref == 'refs/heads/master' && 'production' || 'preview' }} bun run build
 
       - name: Deploy to Cloudflare Pages
         id: cloudflare-deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,9 @@ jobs:
             ${{ runner.os }}-nextjs-
 
       - name: Build
-        run: NEXT_PUBLIC_APP_ENV=${{ github.ref == 'refs/heads/master' && 'production' || 'preview' }} APP_ENV=${{ github.ref == 'refs/heads/master' && 'production' || 'preview' }} bun run build
+        run: bun run build
+        env:
+          NEXT_PUBLIC_APP_ENV: ${{ github.ref == 'refs/heads/master' && 'production' || 'preview' }}
 
       - name: Deploy to Cloudflare Pages
         id: cloudflare-deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,9 @@ jobs:
 
       - name: Build
         run: bun run build
+        env:
+          CF_PAGES_BRANCH: ${{ github.ref == 'refs/heads/master' && 'master' || github.head_ref || github.ref_name }}
+          CF_PAGES_URL: ${{ github.ref != 'refs/heads/master' && 'https://preview.fohte.net' || '' }}
 
       - name: Deploy to Cloudflare Pages
         id: cloudflare-deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,8 +60,7 @@ jobs:
       - name: Build
         run: bun run build
         env:
-          CF_PAGES_BRANCH: ${{ github.ref == 'refs/heads/master' && 'master' || github.head_ref || github.ref_name }}
-          CF_PAGES_URL: ${{ github.ref != 'refs/heads/master' && 'https://preview.fohte.net' || '' }}
+          APP_ENV: ${{ github.ref == 'refs/heads/master' && 'production' || 'preview' }}
 
       - name: Deploy to Cloudflare Pages
         id: cloudflare-deployment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,5 +78,5 @@ jobs:
       - name: Run Percy E2E tests
         run: bun run test:e2e
         env:
-          APP_ENV: test
+          NEXT_PUBLIC_APP_ENV: test
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/percy.config.js
+++ b/percy.config.js
@@ -11,7 +11,7 @@ module.exports = {
   },
   percy: {
     env: {
-      APP_ENV: 'test',
+      NEXT_PUBLIC_APP_ENV: 'test',
     },
   },
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -44,7 +44,7 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
     env: {
-      APP_ENV: 'test',
+      NEXT_PUBLIC_APP_ENV: 'test',
     },
   },
 

--- a/src/app/test/blog/page.tsx
+++ b/src/app/test/blog/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function TestBlogListPage() {
   // テスト環境以外では404を返す
-  if (process.env.APP_ENV !== 'test') {
+  if (process.env.NEXT_PUBLIC_APP_ENV !== 'test') {
     notFound()
   }
 

--- a/src/app/test/blog/page.tsx
+++ b/src/app/test/blog/page.tsx
@@ -15,12 +15,12 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function TestBlogListPage() {
-  // テスト環境以外では404を返す
+  // Return 404 in non-test environments
   if (process.env.NEXT_PUBLIC_APP_ENV !== 'test') {
     notFound()
   }
 
-  // E2Eテスト用記事のみを表示
+  // Display only E2E test posts
   const e2eTestPosts = allPosts
     .filter((post) => post._raw.flattenedPath.includes('e2e-test-'))
     .map((post) => ({

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,6 +1,14 @@
 export const rootDirPath = process.cwd()
 
 const getEnv = (): 'production' | 'preview' | 'development' | 'test' => {
+  // Debug logging
+  console.log('Environment variables:', {
+    APP_ENV: process.env.APP_ENV,
+    NODE_ENV: process.env.NODE_ENV,
+    CF_PAGES_BRANCH: process.env.CF_PAGES_BRANCH,
+    CF_PAGES_URL: process.env.CF_PAGES_URL,
+  })
+
   // APP_ENV takes precedence
   if (
     process.env.APP_ENV === 'production' ||
@@ -8,6 +16,7 @@ const getEnv = (): 'production' | 'preview' | 'development' | 'test' => {
     process.env.APP_ENV === 'development' ||
     process.env.APP_ENV === 'test'
   ) {
+    console.log('Using APP_ENV:', process.env.APP_ENV)
     return process.env.APP_ENV
   }
 
@@ -16,6 +25,7 @@ const getEnv = (): 'production' | 'preview' | 'development' | 'test' => {
     process.env.NODE_ENV === 'development' ||
     process.env.NODE_ENV === 'test'
   ) {
+    console.log('Using NODE_ENV:', process.env.NODE_ENV)
     return process.env.NODE_ENV
   }
 
@@ -23,6 +33,7 @@ const getEnv = (): 'production' | 'preview' | 'development' | 'test' => {
 }
 
 export const env = getEnv()
+console.log('Final env value:', env)
 
 const getBaseUrlString = (): string => {
   switch (env) {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -4,13 +4,10 @@ const getEnv = (): 'production' | 'preview' | 'development' | 'test' => {
   // Debug logging
   console.log('Environment variables:', {
     NEXT_PUBLIC_APP_ENV: process.env.NEXT_PUBLIC_APP_ENV,
-    APP_ENV: process.env.APP_ENV,
     NODE_ENV: process.env.NODE_ENV,
-    CF_PAGES_BRANCH: process.env.CF_PAGES_BRANCH,
-    CF_PAGES_URL: process.env.CF_PAGES_URL,
   })
 
-  // NEXT_PUBLIC_APP_ENV takes highest precedence (for client-side)
+  // NEXT_PUBLIC_APP_ENV takes precedence
   if (
     process.env.NEXT_PUBLIC_APP_ENV === 'production' ||
     process.env.NEXT_PUBLIC_APP_ENV === 'preview' ||
@@ -19,17 +16,6 @@ const getEnv = (): 'production' | 'preview' | 'development' | 'test' => {
   ) {
     console.log('Using NEXT_PUBLIC_APP_ENV:', process.env.NEXT_PUBLIC_APP_ENV)
     return process.env.NEXT_PUBLIC_APP_ENV
-  }
-
-  // APP_ENV takes precedence
-  if (
-    process.env.APP_ENV === 'production' ||
-    process.env.APP_ENV === 'preview' ||
-    process.env.APP_ENV === 'development' ||
-    process.env.APP_ENV === 'test'
-  ) {
-    console.log('Using APP_ENV:', process.env.APP_ENV)
-    return process.env.APP_ENV
   }
 
   if (

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -3,11 +3,23 @@ export const rootDirPath = process.cwd()
 const getEnv = (): 'production' | 'preview' | 'development' | 'test' => {
   // Debug logging
   console.log('Environment variables:', {
+    NEXT_PUBLIC_APP_ENV: process.env.NEXT_PUBLIC_APP_ENV,
     APP_ENV: process.env.APP_ENV,
     NODE_ENV: process.env.NODE_ENV,
     CF_PAGES_BRANCH: process.env.CF_PAGES_BRANCH,
     CF_PAGES_URL: process.env.CF_PAGES_URL,
   })
+
+  // NEXT_PUBLIC_APP_ENV takes highest precedence (for client-side)
+  if (
+    process.env.NEXT_PUBLIC_APP_ENV === 'production' ||
+    process.env.NEXT_PUBLIC_APP_ENV === 'preview' ||
+    process.env.NEXT_PUBLIC_APP_ENV === 'development' ||
+    process.env.NEXT_PUBLIC_APP_ENV === 'test'
+  ) {
+    console.log('Using NEXT_PUBLIC_APP_ENV:', process.env.NEXT_PUBLIC_APP_ENV)
+    return process.env.NEXT_PUBLIC_APP_ENV
+  }
 
   // APP_ENV takes precedence
   if (

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,20 +1,14 @@
 export const rootDirPath = process.cwd()
 
 const getEnv = (): 'production' | 'preview' | 'development' | 'test' => {
+  // APP_ENV takes precedence
   if (
-    process.env.CF_PAGES_BRANCH === 'main' ||
-    process.env.CF_PAGES_BRANCH === 'master'
+    process.env.APP_ENV === 'production' ||
+    process.env.APP_ENV === 'preview' ||
+    process.env.APP_ENV === 'development' ||
+    process.env.APP_ENV === 'test'
   ) {
-    return 'production'
-  }
-
-  if (process.env.CF_PAGES_URL != null) {
-    return 'preview'
-  }
-
-  // APP_ENV takes precedence for test environment
-  if (process.env.APP_ENV === 'test') {
-    return 'test'
+    return process.env.APP_ENV
   }
 
   if (
@@ -35,10 +29,7 @@ const getBaseUrlString = (): string => {
     case 'production':
       return `https://fohte.net`
     case 'preview':
-      if (process.env.CF_PAGES_URL == null) {
-        throw new Error('CF_PAGES_URL must be set')
-      }
-      return process.env.CF_PAGES_URL
+      return `https://preview.fohte.net`
     case 'development':
     case 'test':
       return 'http://localhost:3000'

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -36,7 +36,8 @@ const getBaseUrlString = (): string => {
     case 'production':
       return `https://fohte.net`
     case 'preview':
-      return `https://preview.fohte.net`
+      // Use production URL for preview since the actual preview URL is unpredictable
+      return `https://fohte.net`
     case 'development':
     case 'test':
       return 'http://localhost:3000'
@@ -47,17 +48,15 @@ export const baseUrl = new URL(getBaseUrlString())
 
 export const baseUrlJoin = (path: string): AbsoluteUrl | RelativeUrl => {
   if (env === 'preview') {
-    // preview環境では相対URLを返す
+    // Return relative URLs in preview environment
     const relativePath = path.startsWith('/') ? path : `/${path}`
     return toRelativeUrl(relativePath)
   }
-  // production/development環境では絶対URLを返す
+  // Return absolute URLs in production/development environments
   return toAbsoluteUrl(new URL(path, baseUrl).toString())
 }
 
-// RSS など絶対URLが必要な場合に使用
+// For cases where absolute URLs are required (e.g., RSS feeds)
 export const getAbsoluteUrl = (path: string): AbsoluteUrl => {
-  const baseUrlString =
-    env === 'preview' ? 'https://fohte.net' : getBaseUrlString()
-  return toAbsoluteUrl(new URL(path, baseUrlString).toString())
+  return toAbsoluteUrl(new URL(path, baseUrl).toString())
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,12 +1,6 @@
 export const rootDirPath = process.cwd()
 
 const getEnv = (): 'production' | 'preview' | 'development' | 'test' => {
-  // Debug logging
-  console.log('Environment variables:', {
-    NEXT_PUBLIC_APP_ENV: process.env.NEXT_PUBLIC_APP_ENV,
-    NODE_ENV: process.env.NODE_ENV,
-  })
-
   // NEXT_PUBLIC_APP_ENV takes precedence
   if (
     process.env.NEXT_PUBLIC_APP_ENV === 'production' ||
@@ -14,7 +8,6 @@ const getEnv = (): 'production' | 'preview' | 'development' | 'test' => {
     process.env.NEXT_PUBLIC_APP_ENV === 'development' ||
     process.env.NEXT_PUBLIC_APP_ENV === 'test'
   ) {
-    console.log('Using NEXT_PUBLIC_APP_ENV:', process.env.NEXT_PUBLIC_APP_ENV)
     return process.env.NEXT_PUBLIC_APP_ENV
   }
 
@@ -23,7 +16,6 @@ const getEnv = (): 'production' | 'preview' | 'development' | 'test' => {
     process.env.NODE_ENV === 'development' ||
     process.env.NODE_ENV === 'test'
   ) {
-    console.log('Using NODE_ENV:', process.env.NODE_ENV)
     return process.env.NODE_ENV
   }
 
@@ -31,7 +23,6 @@ const getEnv = (): 'production' | 'preview' | 'development' | 'test' => {
 }
 
 export const env = getEnv()
-console.log('Final env value:', env)
 
 const getBaseUrlString = (): string => {
   switch (env) {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,3 +1,10 @@
+import {
+  AbsoluteUrl,
+  RelativeUrl,
+  toAbsoluteUrl,
+  toRelativeUrl,
+} from '@/utils/url-types'
+
 export const rootDirPath = process.cwd()
 
 const getEnv = (): 'production' | 'preview' | 'development' | 'test' => {
@@ -38,4 +45,19 @@ const getBaseUrlString = (): string => {
 
 export const baseUrl = new URL(getBaseUrlString())
 
-export const baseUrlJoin = (path: string) => new URL(path, baseUrl).toString()
+export const baseUrlJoin = (path: string): AbsoluteUrl | RelativeUrl => {
+  if (env === 'preview') {
+    // preview環境では相対URLを返す
+    const relativePath = path.startsWith('/') ? path : `/${path}`
+    return toRelativeUrl(relativePath)
+  }
+  // production/development環境では絶対URLを返す
+  return toAbsoluteUrl(new URL(path, baseUrl).toString())
+}
+
+// RSS など絶対URLが必要な場合に使用
+export const getAbsoluteUrl = (path: string): AbsoluteUrl => {
+  const baseUrlString =
+    env === 'preview' ? 'https://fohte.net' : getBaseUrlString()
+  return toAbsoluteUrl(new URL(path, baseUrlString).toString())
+}

--- a/src/utils/feed.ts
+++ b/src/utils/feed.ts
@@ -3,17 +3,17 @@
 import { allPosts } from 'contentlayer/generated'
 import { Feed } from 'feed'
 
-import { baseUrl, baseUrlJoin } from '@/utils/config'
+import { getAbsoluteUrl } from '@/utils/config'
 import { mdxToHtml } from '@/utils/mdx'
 
 export const generateFeed = async (): Promise<string> => {
   const feed = new Feed({
     title: 'fohte.net',
-    id: baseUrl.toString(),
-    link: baseUrl.toString(),
-    favicon: baseUrlJoin('/icon.png'),
+    id: getAbsoluteUrl('/'),
+    link: getAbsoluteUrl('/'),
+    favicon: getAbsoluteUrl('/icon.png'),
     copyright: 'All rights reserved 2020, Fohte (Hayato Kawai)',
-    feed: baseUrlJoin('/feed.atom'),
+    feed: getAbsoluteUrl('/feed.atom'),
   })
 
   for (const post of allPosts
@@ -22,12 +22,12 @@ export const generateFeed = async (): Promise<string> => {
     const content = await mdxToHtml(post.body.raw)
     feed.addItem({
       title: post.title,
-      author: [{ name: 'Fohte (Hayato Kawai)', link: baseUrl.toString() }],
+      author: [{ name: 'Fohte (Hayato Kawai)', link: getAbsoluteUrl('/') }],
       content,
       date: new Date(post.date),
       published: new Date(post.date),
       description: post.description,
-      link: baseUrlJoin(post.url),
+      link: getAbsoluteUrl(post.url),
     })
   }
 

--- a/src/utils/url-types.ts
+++ b/src/utils/url-types.ts
@@ -1,0 +1,28 @@
+type Brand<K, T> = K & { __brand: T }
+
+export type AbsoluteUrl = Brand<string, 'AbsoluteUrl'>
+export type RelativeUrl = Brand<string, 'RelativeUrl'>
+
+// Type guards
+export const isAbsoluteUrl = (url: string): url is AbsoluteUrl => {
+  return /^https?:\/\//.test(url)
+}
+
+export const isRelativeUrl = (url: string): url is RelativeUrl => {
+  return url.startsWith('/')
+}
+
+// Constructor functions
+export const toAbsoluteUrl = (url: string): AbsoluteUrl => {
+  if (!isAbsoluteUrl(url)) {
+    throw new Error(`Invalid absolute URL: ${url}`)
+  }
+  return url as AbsoluteUrl
+}
+
+export const toRelativeUrl = (url: string): RelativeUrl => {
+  if (!isRelativeUrl(url)) {
+    throw new Error(`Invalid relative URL: ${url}`)
+  }
+  return url as RelativeUrl
+}


### PR DESCRIPTION
## Why

- When migrating to GitHub Actions deployment in PR #349, the preview environment detection logic was not updated
- Cloudflare Pages environment variables (`CF_PAGES_BRANCH`, `CF_PAGES_URL`) are only available at runtime, but environment detection happens at build time, causing it to fail
- The Google Analytics conditional rendering added in PR #386 doesn't work correctly in preview environments

## What

- Switch to using `NEXT_PUBLIC_APP_ENV` environment variable for environment detection
  - Use `NEXT_PUBLIC_` prefix to ensure the variable is available in client-side bundles
  - Consolidate all environment detection to use this single variable
- Implement Branded Types (`AbsoluteUrl` and `RelativeUrl`) for type-safe URL handling
- Update `baseUrlJoin` to return relative URLs in preview environments
  - This avoids dependency on unpredictable Cloudflare Pages URLs
- Add `getAbsoluteUrl` for cases requiring absolute URLs (e.g., RSS feeds)
  - RSS feeds now use production URL as fallback in preview environments
- Update all test configurations to use `NEXT_PUBLIC_APP_ENV`
- Translate Japanese comments to English

🤖 Generated with [Claude Code](https://claude.ai/code)