### PR TITLE
scripts: fix R2 upload to use remote bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ out/
 test-results/
 playwright-report/
 playwright/.cache/
+
+# Wrangler local state
+.wrangler/

--- a/scripts/upload-image-r2
+++ b/scripts/upload-image-r2
@@ -23,7 +23,7 @@ put_base_path="fohte-net-public-assets/images"
 
 put_object() {
   local image_path="$1"
-  bunx wrangler r2 object put "$put_base_path/$checksum.${image_path##*.}" --file "$image_path"
+  bunx wrangler r2 object put "$put_base_path/$checksum.${image_path##*.}" --file "$image_path" --remote
 }
 
 # create webp (needs to be installed imagemagick)


### PR DESCRIPTION

## Why

- The `wrangler r2 object put` command was missing the `--remote` flag, causing uploads to go to the local R2 emulator instead of the actual bucket
- Since Wrangler v4, `wrangler r2 object` commands default to local emulator mode ([Migration Guide](https://developers.cloudflare.com/workers/wrangler/migration/update-v3-to-v4/))

## What

- Add `--remote` flag to upload to the actual Cloudflare R2 bucket
- Add `.wrangler/` (local emulator data) to `.gitignore`
