### PR TITLE
mdx: add ImageGrid component

### DIFF
--- a/src/components/mdx/ImageGrid.tsx
+++ b/src/components/mdx/ImageGrid.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { Grid } from '@chakra-ui/react'
+import * as React from 'react'
+
+type ImageGridProps = {
+  children: React.ReactNode
+}
+
+export const ImageGrid: React.FC<ImageGridProps> = ({ children }) => {
+  const childCount = React.Children.count(children)
+
+  return (
+    <Grid
+      templateColumns={{
+        base: '1fr',
+        md: `repeat(${childCount}, 1fr)`,
+      }}
+      alignItems="center"
+      gap={4}
+      mt={4}
+      sx={{
+        '& > figure': {
+          mt: 0,
+        },
+      }}
+    >
+      {children}
+    </Grid>
+  )
+}

--- a/src/components/mdx/ImageGrid.tsx
+++ b/src/components/mdx/ImageGrid.tsx
@@ -14,7 +14,7 @@ export const ImageGrid: React.FC<ImageGridProps> = ({ children }) => {
     <Grid
       templateColumns={{
         base: '1fr',
-        md: `repeat(${childCount}, 1fr)`,
+        sm: `repeat(${childCount}, 1fr)`,
       }}
       alignItems="center"
       gap={4}

--- a/src/components/mdx/index.tsx
+++ b/src/components/mdx/index.tsx
@@ -20,6 +20,7 @@ import { CardLink } from '@/components/mdx/CardLink'
 import { CodeBlock } from '@/components/mdx/CodeBlock'
 import { DocsHeading } from '@/components/mdx/DocsHeading'
 import { Image } from '@/components/mdx/Image'
+import { ImageGrid } from '@/components/mdx/ImageGrid'
 import { List } from '@/components/mdx/List'
 import { Mastodon } from '@/components/mdx/Mastodon'
 import { SpeakerDeck } from '@/components/mdx/SpeakerDeck'
@@ -103,6 +104,7 @@ export const mdxComponents: MDXComponents = {
   YouTube: YouTube,
   SpeakerDeck: SpeakerDeck,
   Mastodon: Mastodon,
+  ImageGrid: ImageGrid,
 }
 
 export const rssComponents: MDXComponents = {
@@ -125,5 +127,9 @@ export const rssComponents: MDXComponents = {
 
   CardLink: ({ href, children }: React.ComponentProps<typeof CardLink>) => (
     <a href={href}>{children}</a>
+  ),
+
+  ImageGrid: ({ children }: React.ComponentProps<typeof ImageGrid>) => (
+    <div>{children}</div>
   ),
 }


### PR DESCRIPTION

## Why

- Related images are better displayed side by side

## What

- Add ImageGrid component for horizontal image layout
    - Falls back to vertical layout on mobile (under 480px)
- Vertically center-align images of different heights
