### PR TITLE
astro: add prettier-plugin-astro

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -2,3 +2,5 @@ trailingComma: all
 semi: false
 singleQuote: true
 proseWrap: preserve
+plugins:
+  - prettier-plugin-astro

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,8 +1,8 @@
 import mdx from '@astrojs/mdx'
 import react from '@astrojs/react'
 import tailwindcss from '@tailwindcss/vite'
-import icon from 'astro-icon'
 import { defineConfig } from 'astro/config'
+import icon from 'astro-icon'
 
 export default defineConfig({
   integrations: [react(), mdx(), icon()],

--- a/bun.lock
+++ b/bun.lock
@@ -50,6 +50,7 @@
         "iconv-lite": "0.6.3",
         "jsdom": "26.1.0",
         "prettier": "3.5.3",
+        "prettier-plugin-astro": "0.14.1",
         "textlint": "14.0.4",
         "textlint-rule-preset-ja-technical-writing": "12.0.2",
         "typescript": "5.8.3",
@@ -1531,6 +1532,8 @@
 
     "prettier": ["prettier@3.5.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw=="],
 
+    "prettier-plugin-astro": ["prettier-plugin-astro@0.14.1", "", { "dependencies": { "@astrojs/compiler": "^2.9.1", "prettier": "^3.0.0", "sass-formatter": "^0.7.6" } }, "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw=="],
+
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "prh": ["prh@5.4.4", "", { "dependencies": { "commandpost": "^1.2.1", "diff": "^4.0.1", "js-yaml": "^3.9.1" }, "bin": { "prh": "./bin/prh" } }, "sha512-UATF+R/2H8owxwPvF12Knihu9aYGTuZttGHrEEq5NBWz38mREh23+WvCVKX3fhnIZIMV7ye6E1fnqAl+V6WYEw=="],
@@ -1669,6 +1672,8 @@
 
     "rxjs": ["rxjs@7.8.1", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg=="],
 
+    "s.color": ["s.color@0.0.15", "", {}, "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA=="],
+
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
     "safe-array-concat": ["safe-array-concat@1.0.1", "", { "dependencies": { "call-bind": "^1.0.2", "get-intrinsic": "^1.2.1", "has-symbols": "^1.0.3", "isarray": "^2.0.5" } }, "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q=="],
@@ -1680,6 +1685,8 @@
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "sass": ["sass@1.89.2", "", { "dependencies": { "chokidar": "^4.0.0", "immutable": "^5.0.2", "source-map-js": ">=0.6.2 <2.0.0" }, "optionalDependencies": { "@parcel/watcher": "^2.4.1" }, "bin": { "sass": "sass.js" } }, "sha512-xCmtksBKd/jdJ9Bt9p7nPKiuqrlBMBuuGkQlkhZjjQk3Ty48lv93k5Dq6OPkKt4XwxDJ7tvlfrTa1MPA9bf+QA=="],
+
+    "sass-formatter": ["sass-formatter@0.7.9", "", { "dependencies": { "suf-log": "^2.5.3" } }, "sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw=="],
 
     "sax": ["sax@1.4.3", "", {}, "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ=="],
 
@@ -1768,6 +1775,8 @@
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
+
+    "suf-log": ["suf-log@2.5.3", "", { "dependencies": { "s.color": "0.0.15" } }, "sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow=="],
 
     "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "iconv-lite": "0.6.3",
     "jsdom": "26.1.0",
     "prettier": "3.5.3",
+    "prettier-plugin-astro": "0.14.1",
     "textlint": "14.0.4",
     "textlint-rule-preset-ja-technical-writing": "12.0.2",
     "typescript": "5.8.3",

--- a/src/components/astro/Header.astro
+++ b/src/components/astro/Header.astro
@@ -13,9 +13,14 @@ const navLinks = [
 ---
 
 <header>
-  <div class="mx-auto flex max-w-[780px] items-center justify-between px-4 py-6 sm:px-6 md:px-8">
+  <div
+    class="mx-auto flex max-w-[780px] items-center justify-between px-4 py-6 sm:px-6 md:px-8"
+  >
     <h1 class="text-xl font-bold leading-tight">
-      <a href="/" class="flex items-center gap-4 text-black no-underline hover:opacity-80">
+      <a
+        href="/"
+        class="flex items-center gap-4 text-black no-underline hover:opacity-80"
+      >
         <img src="/icon.png" alt="" class="h-[1.5em] w-[1.5em]" />
         <span>{siteTitle}</span>
       </a>

--- a/src/components/astro/SocialList.astro
+++ b/src/components/astro/SocialList.astro
@@ -29,7 +29,11 @@ const socialList = [
           href={social.href}
           class="inline-flex items-center gap-2 text-gray-700 no-underline hover:text-gray-900"
           target="_blank"
-          rel={social.rel ? `${social.rel} noopener noreferrer` : 'noopener noreferrer'}
+          rel={
+            social.rel
+              ? `${social.rel} noopener noreferrer`
+              : 'noopener noreferrer'
+          }
         >
           <Icon name={social.icon} class="h-4 w-4" />
           <span>{social.text}</span>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -32,8 +32,7 @@ import SocialList from '../components/astro/SocialList.astro'
               href="https://www.wantedly.com/id/fohte"
               class="text-blue-500 hover:underline"
               target="_blank"
-              rel="noopener noreferrer"
-              >wantedly.com/id/fohte</a
+              rel="noopener noreferrer">wantedly.com/id/fohte</a
             >
           </p>
         </section>


### PR DESCRIPTION
## Why

- from: https://github.com/fohte/fohte.net/pull/405
- Formatter is necessary to maintain code quality

## What

- Add `prettier-plugin-astro` to devDependencies and enable it in `.prettierrc.yml`
- Format existing `.astro` files
