### PR TITLE
astro: add prettier-plugin-tailwindcss

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -4,3 +4,6 @@ singleQuote: true
 proseWrap: preserve
 plugins:
   - prettier-plugin-astro
+  # prettier-plugin-tailwindcss must be loaded last
+  # ref: https://github.com/tailwindlabs/prettier-plugin-tailwindcss?tab=readme-ov-file#compatibility-with-other-prettier-plugins
+  - prettier-plugin-tailwindcss

--- a/bun.lock
+++ b/bun.lock
@@ -51,6 +51,7 @@
         "jsdom": "26.1.0",
         "prettier": "3.5.3",
         "prettier-plugin-astro": "0.14.1",
+        "prettier-plugin-tailwindcss": "0.7.2",
         "textlint": "14.0.4",
         "textlint-rule-preset-ja-technical-writing": "12.0.2",
         "typescript": "5.8.3",
@@ -1533,6 +1534,8 @@
     "prettier": ["prettier@3.5.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw=="],
 
     "prettier-plugin-astro": ["prettier-plugin-astro@0.14.1", "", { "dependencies": { "@astrojs/compiler": "^2.9.1", "prettier": "^3.0.0", "sass-formatter": "^0.7.6" } }, "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw=="],
+
+    "prettier-plugin-tailwindcss": ["prettier-plugin-tailwindcss@0.7.2", "", { "peerDependencies": { "@ianvs/prettier-plugin-sort-imports": "*", "@prettier/plugin-hermes": "*", "@prettier/plugin-oxc": "*", "@prettier/plugin-pug": "*", "@shopify/prettier-plugin-liquid": "*", "@trivago/prettier-plugin-sort-imports": "*", "@zackad/prettier-plugin-twig": "*", "prettier": "^3.0", "prettier-plugin-astro": "*", "prettier-plugin-css-order": "*", "prettier-plugin-jsdoc": "*", "prettier-plugin-marko": "*", "prettier-plugin-multiline-arrays": "*", "prettier-plugin-organize-attributes": "*", "prettier-plugin-organize-imports": "*", "prettier-plugin-sort-imports": "*", "prettier-plugin-svelte": "*" }, "optionalPeers": ["@ianvs/prettier-plugin-sort-imports", "@prettier/plugin-hermes", "@prettier/plugin-oxc", "@prettier/plugin-pug", "@shopify/prettier-plugin-liquid", "@trivago/prettier-plugin-sort-imports", "@zackad/prettier-plugin-twig", "prettier-plugin-astro", "prettier-plugin-css-order", "prettier-plugin-jsdoc", "prettier-plugin-marko", "prettier-plugin-multiline-arrays", "prettier-plugin-organize-attributes", "prettier-plugin-organize-imports", "prettier-plugin-sort-imports", "prettier-plugin-svelte"] }, "sha512-LkphyK3Fw+q2HdMOoiEHWf93fNtYJwfamoKPl7UwtjFQdei/iIBoX11G6j706FzN3ymX9mPVi97qIY8328vdnA=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "jsdom": "26.1.0",
     "prettier": "3.5.3",
     "prettier-plugin-astro": "0.14.1",
+    "prettier-plugin-tailwindcss": "0.7.2",
     "textlint": "14.0.4",
     "textlint-rule-preset-ja-technical-writing": "12.0.2",
     "typescript": "5.8.3",

--- a/src/components/astro/Counter.tsx
+++ b/src/components/astro/Counter.tsx
@@ -9,20 +9,20 @@ export function Counter({ initial = 0 }: CounterProps) {
   const [count, setCount] = useState(initial)
 
   return (
-    <div className="flex items-center gap-4 p-4 rounded-lg bg-gray-100">
+    <div className="flex items-center gap-4 rounded-lg bg-gray-100 p-4">
       <Slot>
         <span className="text-2xl font-bold">{count}</span>
       </Slot>
       <button
         type="button"
-        className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors"
+        className="rounded bg-blue-500 px-4 py-2 text-white transition-colors hover:bg-blue-600"
         onClick={() => setCount((c) => c - 1)}
       >
         -
       </button>
       <button
         type="button"
-        className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors"
+        className="rounded bg-blue-500 px-4 py-2 text-white transition-colors hover:bg-blue-600"
         onClick={() => setCount((c) => c + 1)}
       >
         +

--- a/src/components/astro/Header.astro
+++ b/src/components/astro/Header.astro
@@ -16,7 +16,7 @@ const navLinks = [
   <div
     class="mx-auto flex max-w-[780px] items-center justify-between px-4 py-6 sm:px-6 md:px-8"
   >
-    <h1 class="text-xl font-bold leading-tight">
+    <h1 class="text-xl leading-tight font-bold">
       <a
         href="/"
         class="flex items-center gap-4 text-black no-underline hover:opacity-80"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,7 +7,7 @@ import SocialList from '../components/astro/SocialList.astro'
   <div class="mx-auto max-w-[780px] px-4 py-8 sm:px-6 md:px-8">
     <div class="flex flex-col items-center justify-center gap-10">
       <div class="flex flex-col items-center justify-center gap-4 text-center">
-        <h2 class="text-3xl font-bold leading-tight md:text-4xl">
+        <h2 class="text-3xl leading-tight font-bold md:text-4xl">
           Fohte (Hayato Kawai)
         </h2>
         <p>Gamer / Software Engineer (Cloud Infrastructure Engineer)</p>


### PR DESCRIPTION
## Why

- from: https://github.com/fohte/fohte.net/pull/405
- Tailwind CSS classes should also be formatted

## What

- Add `prettier-plugin-tailwindcss` to automatically sort Tailwind classes in the recommended order (layout → spacing → typography → colors → effects)
- Configure plugin load order according to official documentation for compatibility with `prettier-plugin-astro`
