### PR TITLE
astro: add blog tag pages and tag links

### DIFF
--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -29,7 +29,7 @@ const formattedDate = format(post.data.date, 'yyyy-MM-dd')
         {formattedDate}
       </time>
       {
-        post.data.tags && (
+        post.data.tags && post.data.tags.length > 0 && (
           <div class="mt-2 flex flex-wrap gap-2">
             {post.data.tags.map((tag) => (
               <a

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -32,9 +32,12 @@ const formattedDate = format(post.data.date, 'yyyy-MM-dd')
         post.data.tags && (
           <div class="mt-2 flex flex-wrap gap-2">
             {post.data.tags.map((tag) => (
-              <span class="rounded bg-gray-200 px-2 py-1 text-sm text-gray-700">
+              <a
+                href={`/blog/tags/${tag}`}
+                class="rounded bg-gray-100 px-2 py-1 text-sm text-gray-500 transition-colors hover:bg-gray-200"
+              >
                 {tag}
-              </span>
+              </a>
             ))}
           </div>
         )

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -16,12 +16,9 @@ const sortedPosts = posts.sort(
     <ul class="space-y-6">
       {
         sortedPosts.map((post) => (
-          <li>
-            <a
-              href={`/blog/${post.id}`}
-              class="block rounded-lg p-4 transition-colors hover:bg-gray-100"
-            >
-              <h2 class="text-xl font-semibold text-gray-900">
+          <li class="rounded-lg p-4">
+            <a href={`/blog/${post.id}`} class="group">
+              <h2 class="text-xl font-semibold text-gray-900 group-hover:text-blue-600">
                 {post.data.title}
               </h2>
               <time
@@ -30,22 +27,22 @@ const sortedPosts = posts.sort(
               >
                 {format(post.data.date, 'yyyy-MM-dd')}
               </time>
-              {post.data.tags && post.data.tags.length > 0 && (
-                <div class="mt-2 flex flex-wrap gap-2">
-                  {post.data.tags.map((tag) => (
-                    <a
-                      href={`/blog/tags/${tag}`}
-                      class="rounded bg-gray-100 px-2 py-0.5 text-sm text-gray-500 transition-colors hover:bg-gray-200"
-                    >
-                      {tag}
-                    </a>
-                  ))}
-                </div>
-              )}
-              {post.data.description && (
-                <p class="mt-2 text-gray-600">{post.data.description}</p>
-              )}
             </a>
+            {post.data.tags && post.data.tags.length > 0 && (
+              <div class="mt-2 flex flex-wrap gap-2">
+                {post.data.tags.map((tag) => (
+                  <a
+                    href={`/blog/tags/${tag}`}
+                    class="rounded bg-gray-100 px-2 py-0.5 text-sm text-gray-500 transition-colors hover:bg-gray-200"
+                  >
+                    {tag}
+                  </a>
+                ))}
+              </div>
+            )}
+            {post.data.description && (
+              <p class="mt-2 text-gray-600">{post.data.description}</p>
+            )}
           </li>
         ))
       }

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -30,12 +30,15 @@ const sortedPosts = posts.sort(
               >
                 {format(post.data.date, 'yyyy-MM-dd')}
               </time>
-              {post.data.tags && (
+              {post.data.tags && post.data.tags.length > 0 && (
                 <div class="mt-2 flex flex-wrap gap-2">
                   {post.data.tags.map((tag) => (
-                    <span class="rounded bg-gray-100 px-2 py-0.5 text-sm text-gray-500">
+                    <a
+                      href={`/blog/tags/${tag}`}
+                      class="rounded bg-gray-100 px-2 py-0.5 text-sm text-gray-500 transition-colors hover:bg-gray-200"
+                    >
                       {tag}
-                    </span>
+                    </a>
                   ))}
                 </div>
               )}

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -37,12 +37,9 @@ const { tag, posts } = Astro.props
     <ul class="space-y-6">
       {
         posts.map((post) => (
-          <li>
-            <a
-              href={`/blog/${post.id}`}
-              class="block rounded-lg p-4 transition-colors hover:bg-gray-100"
-            >
-              <h2 class="text-xl font-semibold text-gray-900">
+          <li class="rounded-lg p-4">
+            <a href={`/blog/${post.id}`} class="group">
+              <h2 class="text-xl font-semibold text-gray-900 group-hover:text-blue-600">
                 {post.data.title}
               </h2>
               <time
@@ -51,28 +48,28 @@ const { tag, posts } = Astro.props
               >
                 {format(post.data.date, 'yyyy-MM-dd')}
               </time>
-              {post.data.tags && post.data.tags.length > 0 && (
-                <div class="mt-2 flex flex-wrap gap-2">
-                  {post.data.tags.map((t) =>
-                    t === tag ? (
-                      <span class="rounded bg-gray-300 px-2 py-0.5 text-sm text-gray-800">
-                        {t}
-                      </span>
-                    ) : (
-                      <a
-                        href={`/blog/tags/${t}`}
-                        class="rounded bg-gray-100 px-2 py-0.5 text-sm text-gray-500 transition-colors hover:bg-gray-200"
-                      >
-                        {t}
-                      </a>
-                    ),
-                  )}
-                </div>
-              )}
-              {post.data.description && (
-                <p class="mt-2 text-gray-600">{post.data.description}</p>
-              )}
             </a>
+            {post.data.tags && post.data.tags.length > 0 && (
+              <div class="mt-2 flex flex-wrap gap-2">
+                {post.data.tags.map((t) =>
+                  t === tag ? (
+                    <span class="rounded bg-gray-300 px-2 py-0.5 text-sm text-gray-800">
+                      {t}
+                    </span>
+                  ) : (
+                    <a
+                      href={`/blog/tags/${t}`}
+                      class="rounded bg-gray-100 px-2 py-0.5 text-sm text-gray-500 transition-colors hover:bg-gray-200"
+                    >
+                      {t}
+                    </a>
+                  ),
+                )}
+              </div>
+            )}
+            {post.data.description && (
+              <p class="mt-2 text-gray-600">{post.data.description}</p>
+            )}
           </li>
         ))
       }

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -6,14 +6,24 @@ import BaseLayout from '@/layouts/BaseLayout.astro'
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts')
-  const tags = [...new Set(posts.flatMap((post) => post.data.tags ?? []))]
-  return tags.map((tag) => ({
+  const postsByTag = new Map<string, typeof posts>()
+
+  for (const post of posts) {
+    for (const tag of post.data.tags ?? []) {
+      if (!postsByTag.has(tag)) {
+        postsByTag.set(tag, [])
+      }
+      postsByTag.get(tag)!.push(post)
+    }
+  }
+
+  return Array.from(postsByTag.entries()).map(([tag, tagPosts]) => ({
     params: { tag },
     props: {
       tag,
-      posts: posts
-        .filter((post) => post.data.tags?.includes(tag))
-        .sort((a, b) => b.data.date.getTime() - a.data.date.getTime()),
+      posts: tagPosts.sort(
+        (a, b) => b.data.date.getTime() - a.data.date.getTime(),
+      ),
     },
   }))
 }
@@ -41,20 +51,22 @@ const { tag, posts } = Astro.props
               >
                 {format(post.data.date, 'yyyy-MM-dd')}
               </time>
-              {post.data.tags && (
+              {post.data.tags && post.data.tags.length > 0 && (
                 <div class="mt-2 flex flex-wrap gap-2">
-                  {post.data.tags.map((t) => (
-                    <span
-                      class:list={[
-                        'rounded px-2 py-0.5 text-sm',
-                        t === tag
-                          ? 'bg-gray-300 text-gray-800'
-                          : 'bg-gray-100 text-gray-500',
-                      ]}
-                    >
-                      {t}
-                    </span>
-                  ))}
+                  {post.data.tags.map((t) =>
+                    t === tag ? (
+                      <span class="rounded bg-gray-300 px-2 py-0.5 text-sm text-gray-800">
+                        {t}
+                      </span>
+                    ) : (
+                      <a
+                        href={`/blog/tags/${t}`}
+                        class="rounded bg-gray-100 px-2 py-0.5 text-sm text-gray-500 transition-colors hover:bg-gray-200"
+                      >
+                        {t}
+                      </a>
+                    ),
+                  )}
                 </div>
               )}
               {post.data.description && (

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -4,18 +4,29 @@ import { format } from 'date-fns'
 
 import BaseLayout from '@/layouts/BaseLayout.astro'
 
-const posts = await getCollection('posts')
-const sortedPosts = posts.sort(
-  (a, b) => b.data.date.getTime() - a.data.date.getTime(),
-)
+export async function getStaticPaths() {
+  const posts = await getCollection('posts')
+  const tags = [...new Set(posts.flatMap((post) => post.data.tags ?? []))]
+  return tags.map((tag) => ({
+    params: { tag },
+    props: {
+      tag,
+      posts: posts
+        .filter((post) => post.data.tags?.includes(tag))
+        .sort((a, b) => b.data.date.getTime() - a.data.date.getTime()),
+    },
+  }))
+}
+
+const { tag, posts } = Astro.props
 ---
 
-<BaseLayout title="Blog">
+<BaseLayout title={`Tag: ${tag}`}>
   <div class="mx-auto max-w-[780px] px-4 py-8 sm:px-6 md:px-8">
-    <h1 class="mb-8 text-3xl font-bold">Blog</h1>
+    <h1 class="mb-8 text-3xl font-bold">Tag: {tag}</h1>
     <ul class="space-y-6">
       {
-        sortedPosts.map((post) => (
+        posts.map((post) => (
           <li>
             <a
               href={`/blog/${post.id}`}
@@ -32,9 +43,16 @@ const sortedPosts = posts.sort(
               </time>
               {post.data.tags && (
                 <div class="mt-2 flex flex-wrap gap-2">
-                  {post.data.tags.map((tag) => (
-                    <span class="rounded bg-gray-100 px-2 py-0.5 text-sm text-gray-500">
-                      {tag}
+                  {post.data.tags.map((t) => (
+                    <span
+                      class:list={[
+                        'rounded px-2 py-0.5 text-sm',
+                        t === tag
+                          ? 'bg-gray-300 text-gray-800'
+                          : 'bg-gray-100 text-gray-500',
+                      ]}
+                    >
+                      {t}
                     </span>
                   ))}
                 </div>


### PR DESCRIPTION
## Why

- from: https://github.com/fohte/fohte.net/pull/405

## What

- Add `/blog/tags/[tag]` pages to allow browsing blog posts filtered by tag
- Display tag badges on individual post pages and the blog index, with links to the corresponding tag pages on individual posts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/fohte.net/pull/421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
