### PR TITLE
astro: migrate static pages to Astro (Phase 5b)

### DIFF
--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -1,0 +1,73 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro'
+---
+
+<BaseLayout title="プライバシーポリシー">
+  <div class="mx-auto max-w-[780px] px-4 py-8 leading-relaxed sm:px-6 md:px-8">
+    <h1 class="mb-6 text-2xl font-bold">プライバシーポリシー</h1>
+
+    <h3 class="mt-8 mb-4 text-xl font-bold">はじめに</h3>
+    <p>
+      このプライバシーポリシーは、当サイト (以下「本サイト」といいます)
+      が、利用者 (以下「ユーザー」といいます)
+      の個人情報をどのように取り扱うかについて説明するものです。本サイトは、ユーザーのプライバシーを尊重し、適切に個人情報を保護することをお約束します。
+    </p>
+
+    <h3 class="mt-8 mb-4 text-xl font-bold">収集する情報</h3>
+    <p>本サイトでは、以下の情報を収集することがあります。</p>
+    <ol class="my-4 list-decimal space-y-2 pl-6">
+      <li>
+        <p class="font-bold">Google Analytics</p>
+        <p>
+          本サイトでは、アクセス解析のために Google Analytics
+          を利用しています。Google Analytics は、Cookie
+          を使用して、ユーザーのサイト利用状況を収集・分析します。このデータは、匿名で収集されており、特定の個人を識別することはできません。Google
+          Analytics の詳細については、<a
+            href="https://policies.google.com/privacy"
+            class="text-blue-500 hover:underline"
+            target="_blank"
+            rel="noopener noreferrer">Google のプライバシーポリシー</a
+          >をご覧ください。
+        </p>
+      </li>
+      <li>
+        <p class="font-bold">Amazon アソシエイト</p>
+        <p>
+          本サイトは、Amazon アソシエイトプログラムに参加しています。Amazon
+          アソシエイトとして、適格販売により収入を得ることがあります。Amazon
+          アソシエイトリンクを通じて購入が行われた場合、Cookie
+          が使用され、購入履歴がトラッキングされます。Amazon
+          のプライバシーポリシーについては、<a
+            href="https://www.amazon.co.jp/gp/help/customer/display.html?nodeId=201909010"
+            class="text-blue-500 hover:underline"
+            target="_blank"
+            rel="noopener noreferrer">Amazon のプライバシーポリシー</a
+          >をご覧ください。
+        </p>
+      </li>
+    </ol>
+
+    <h3 class="mt-8 mb-4 text-xl font-bold">個人情報の利用目的</h3>
+    <p>収集した情報は、以下の目的で利用されます。</p>
+    <ul class="my-2 list-disc pl-6">
+      <li>サイトの運営・管理のため</li>
+      <li>サイトの利用状況の分析およびサービスの改善のため</li>
+      <li>広告の提供およびコンテンツのパーソナライズのため</li>
+    </ul>
+
+    <h3 class="mt-8 mb-4 text-xl font-bold">個人情報の第三者提供</h3>
+    <p>
+      本サイトは、法令に基づく場合を除き、ユーザーの個人情報を第三者に提供することはありません。
+    </p>
+
+    <h3 class="mt-8 mb-4 text-xl font-bold">Cookie の使用について</h3>
+    <p>
+      本サイトでは、ユーザーの利便性向上や利用状況の分析のために Cookie
+      を使用しています。ユーザーはブラウザの設定により、Cookie
+      の受け入れを拒否することができますが、その場合、一部の機能が利用できなくなることがあります。
+    </p>
+
+    <h3 class="mt-8 mb-4 text-xl font-bold">プライバシーポリシーの変更</h3>
+    <p>本プライバシーポリシーは、必要に応じて変更されることがあります。</p>
+  </div>
+</BaseLayout>

--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -6,14 +6,14 @@ import BaseLayout from '../layouts/BaseLayout.astro'
   <div class="mx-auto max-w-[780px] px-4 py-8 leading-relaxed sm:px-6 md:px-8">
     <h1 class="mb-6 text-2xl font-bold">プライバシーポリシー</h1>
 
-    <h3 class="mt-8 mb-4 text-xl font-bold">はじめに</h3>
+    <h2 class="mt-8 mb-4 text-xl font-bold">はじめに</h2>
     <p>
       このプライバシーポリシーは、当サイト (以下「本サイト」といいます)
       が、利用者 (以下「ユーザー」といいます)
       の個人情報をどのように取り扱うかについて説明するものです。本サイトは、ユーザーのプライバシーを尊重し、適切に個人情報を保護することをお約束します。
     </p>
 
-    <h3 class="mt-8 mb-4 text-xl font-bold">収集する情報</h3>
+    <h2 class="mt-8 mb-4 text-xl font-bold">収集する情報</h2>
     <p>本サイトでは、以下の情報を収集することがあります。</p>
     <ol class="my-4 list-decimal space-y-2 pl-6">
       <li>
@@ -47,7 +47,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
       </li>
     </ol>
 
-    <h3 class="mt-8 mb-4 text-xl font-bold">個人情報の利用目的</h3>
+    <h2 class="mt-8 mb-4 text-xl font-bold">個人情報の利用目的</h2>
     <p>収集した情報は、以下の目的で利用されます。</p>
     <ul class="my-2 list-disc pl-6">
       <li>サイトの運営・管理のため</li>
@@ -55,19 +55,19 @@ import BaseLayout from '../layouts/BaseLayout.astro'
       <li>広告の提供およびコンテンツのパーソナライズのため</li>
     </ul>
 
-    <h3 class="mt-8 mb-4 text-xl font-bold">個人情報の第三者提供</h3>
+    <h2 class="mt-8 mb-4 text-xl font-bold">個人情報の第三者提供</h2>
     <p>
       本サイトは、法令に基づく場合を除き、ユーザーの個人情報を第三者に提供することはありません。
     </p>
 
-    <h3 class="mt-8 mb-4 text-xl font-bold">Cookie の使用について</h3>
+    <h2 class="mt-8 mb-4 text-xl font-bold">Cookie の使用について</h2>
     <p>
       本サイトでは、ユーザーの利便性向上や利用状況の分析のために Cookie
       を使用しています。ユーザーはブラウザの設定により、Cookie
       の受け入れを拒否することができますが、その場合、一部の機能が利用できなくなることがあります。
     </p>
 
-    <h3 class="mt-8 mb-4 text-xl font-bold">プライバシーポリシーの変更</h3>
+    <h2 class="mt-8 mb-4 text-xl font-bold">プライバシーポリシーの変更</h2>
     <p>本プライバシーポリシーは、必要に応じて変更されることがあります。</p>
   </div>
 </BaseLayout>

--- a/src/pages/projects/bms.astro
+++ b/src/pages/projects/bms.astro
@@ -11,9 +11,13 @@ import BaseLayout from '../../layouts/BaseLayout.astro'
       <table class="w-full border-collapse text-sm">
         <thead>
           <tr class="border-b border-gray-300">
-            <th class="px-3 py-2 text-left font-semibold">タイトル</th>
-            <th class="px-3 py-2 text-left font-semibold">視聴リンク</th>
-            <th class="px-3 py-2 text-left font-semibold">説明</th>
+            <th scope="col" class="px-3 py-2 text-left font-semibold"
+              >タイトル</th
+            >
+            <th scope="col" class="px-3 py-2 text-left font-semibold"
+              >視聴リンク</th
+            >
+            <th scope="col" class="px-3 py-2 text-left font-semibold">説明</th>
           </tr>
         </thead>
         <tbody>
@@ -52,11 +56,14 @@ import BaseLayout from '../../layouts/BaseLayout.astro'
       <table class="w-full border-collapse text-sm">
         <thead>
           <tr class="border-b border-gray-300">
-            <th class="px-3 py-2 text-left font-semibold">レベル</th>
-            <th class="px-3 py-2 text-left font-semibold">タイトル</th>
-            <th class="px-3 py-2 text-left font-semibold">動画</th>
-            <th class="px-3 py-2 text-left font-semibold">IR</th>
-            <th class="px-3 py-2 text-left font-semibold">補足</th>
+            <th scope="col" class="px-3 py-2 text-left font-semibold">レベル</th
+            >
+            <th scope="col" class="px-3 py-2 text-left font-semibold"
+              >タイトル</th
+            >
+            <th scope="col" class="px-3 py-2 text-left font-semibold">動画</th>
+            <th scope="col" class="px-3 py-2 text-left font-semibold">IR</th>
+            <th scope="col" class="px-3 py-2 text-left font-semibold">補足</th>
           </tr>
         </thead>
         <tbody>

--- a/src/pages/projects/bms.astro
+++ b/src/pages/projects/bms.astro
@@ -1,0 +1,233 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro'
+---
+
+<BaseLayout title="BMS products">
+  <div class="mx-auto max-w-[780px] px-4 py-8 sm:px-6 md:px-8">
+    <h1 class="mb-6 text-2xl font-bold">BMS products</h1>
+
+    <h2 class="mt-8 mb-4 text-xl font-bold">BMS</h2>
+    <div class="overflow-x-auto">
+      <table class="w-full border-collapse text-sm">
+        <thead>
+          <tr class="border-b border-gray-300">
+            <th class="px-3 py-2 text-left font-semibold">タイトル</th>
+            <th class="px-3 py-2 text-left font-semibold">視聴リンク</th>
+            <th class="px-3 py-2 text-left font-semibold">説明</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-b border-gray-200">
+            <td class="px-3 py-2">
+              <a
+                href="https://assets.fohte.net/projects/bms/Scafohld.zip"
+                class="text-blue-500 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer">Scafohld</a
+              >
+            </td>
+            <td class="px-3 py-2">
+              <a
+                href="https://soundcloud.com/fohte/scafohld"
+                class="text-blue-500 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer">SoundCloud</a
+              >
+            </td>
+            <td class="px-3 py-2">
+              「第 10 回自称無名 BMS 作家が物申す!」参加曲 (<a
+                href="https://manbow.nothing.sh/event/event.cgi?action=More_def&num=36&event=86"
+                class="text-blue-500 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer">イベントページ</a
+              >)
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h2 class="mt-8 mb-4 text-xl font-bold">差分</h2>
+    <div class="overflow-x-auto">
+      <table class="w-full border-collapse text-sm">
+        <thead>
+          <tr class="border-b border-gray-300">
+            <th class="px-3 py-2 text-left font-semibold">レベル</th>
+            <th class="px-3 py-2 text-left font-semibold">タイトル</th>
+            <th class="px-3 py-2 text-left font-semibold">動画</th>
+            <th class="px-3 py-2 text-left font-semibold">IR</th>
+            <th class="px-3 py-2 text-left font-semibold">補足</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-b border-gray-200">
+            <td class="px-3 py-2">★16 (?)</td>
+            <td class="px-3 py-2">
+              <a
+                href="https://assets.fohte.net/projects/bms/_abs07_Fohte.bme"
+                class="text-blue-500 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer">Absurd Gaff [Fohter]</a
+              >
+            </td>
+            <td class="px-3 py-2">
+              <a
+                href="https://youtube.com/watch?v=X8XMcAHMwks"
+                class="text-blue-500 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer">YouTube</a
+              >
+            </td>
+            <td class="px-3 py-2">
+              <a
+                href="http://dream-pro.info/~lavalse/LR2IR/search.cgi?mode=ranking&bmsid=146845"
+                class="text-blue-500 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer">LR2</a
+              >
+            </td>
+            <td class="px-3 py-2"
+              >初差分作成。同梱穴譜面の密度を高くした感じ。</td
+            >
+          </tr>
+          <tr class="border-b border-gray-200">
+            <td class="px-3 py-2">★12 (?)</td>
+            <td class="px-3 py-2">
+              <a
+                href="https://assets.fohte.net/projects/bms/_nostalgia_fohter.bml"
+                class="text-blue-500 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer">time from nostalgia [Fohter]</a
+              >
+            </td>
+            <td class="px-3 py-2">
+              <a
+                href="https://youtube.com/watch?v=BqkY8fa3iWg"
+                class="text-blue-500 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer">YouTube</a
+              >
+            </td>
+            <td class="px-3 py-2">
+              <a
+                href="http://dream-pro.info/~lavalse/LR2IR/search.cgi?mode=ranking&bmsid=146995"
+                class="text-blue-500 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer">LR2</a
+              >
+            </td>
+            <td class="px-3 py-2">同時押しマシマシ</td>
+          </tr>
+          <tr class="border-b border-gray-200">
+            <td class="px-3 py-2">★18 (?)</td>
+            <td class="px-3 py-2">
+              <a
+                href="https://assets.fohte.net/projects/bms/andromeda_fohter.bme"
+                class="text-blue-500 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer">Andromeda [Fohter]</a
+              >
+            </td>
+            <td class="px-3 py-2"></td>
+            <td class="px-3 py-2">
+              <a
+                href="http://dream-pro.info/~lavalse/LR2IR/search.cgi?mode=ranking&bmsid=148565"
+                class="text-blue-500 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer">LR2</a
+              >
+            </td>
+            <td class="px-3 py-2">quell + Almagest</td>
+          </tr>
+          <tr class="border-b border-gray-200">
+            <td class="px-3 py-2">★★2 (?)</td>
+            <td class="px-3 py-2">
+              <a
+                href="https://assets.fohte.net/projects/bms/angelic7Fohter.bme"
+                class="text-blue-500 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer">Angelic layer 玄人</a
+              >
+            </td>
+            <td class="px-3 py-2"></td>
+            <td class="px-3 py-2">
+              <a
+                href="http://dream-pro.info/~lavalse/LR2IR/search.cgi?mode=ranking&bmsid=166050"
+                class="text-blue-500 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer">LR2</a
+              >
+            </td>
+            <td class="px-3 py-2">
+              某 Overjoy 譜面の密度を薄くして長い縦連も少し崩した譜面。<br
+              />でもやっぱり難しい。
+            </td>
+          </tr>
+          <tr class="border-b border-gray-200">
+            <td class="px-3 py-2">★18 (?)</td>
+            <td class="px-3 py-2">
+              <a
+                href="https://assets.fohte.net/projects/bms/_akasagarbha_7fo.bme"
+                class="text-blue-500 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer">Akasagarbha -PRO-</a
+              >
+            </td>
+            <td class="px-3 py-2">
+              <a
+                href="https://youtube.com/watch?v=LlXyMes0ubE"
+                class="text-blue-500 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer">YouTube</a
+              >
+            </td>
+            <td class="px-3 py-2">
+              <a
+                href="http://dream-pro.info/~lavalse/LR2IR/search.cgi?mode=ranking&bmsid=166048"
+                class="text-blue-500 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer">LR2</a
+              >
+            </td>
+            <td class="px-3 py-2">
+              ブレイク明け寸前から発狂する感じのラス殺し譜面が一度作ってみたかった。<br
+              />無音ノーツ・手動ディレイほんの少し有り。
+            </td>
+          </tr>
+          <tr class="border-b border-gray-200">
+            <td class="px-3 py-2">★5 (?)</td>
+            <td class="px-3 py-2">
+              <a
+                href="https://assets.fohte.net/projects/bms/locker(F).bms"
+                class="text-blue-500 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer">ロッカー -STREAM-</a
+              >
+            </td>
+            <td class="px-3 py-2">
+              <a
+                href="https://youtube.com/watch?v=thgTUGAWavA"
+                class="text-blue-500 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer">YouTube</a
+              >
+            </td>
+            <td class="px-3 py-2">
+              <a
+                href="http://dream-pro.info/~lavalse/LR2IR/search.cgi?mode=ranking&bmsid=166252"
+                class="text-blue-500 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer">LR2</a
+              >
+            </td>
+            <td class="px-3 py-2">
+              発狂低難易度を目指して作ってみた。<br
+              />高速曲も相まって難しめになってた。<br />BPM 194 の 16
+              分トリルや簡単な皿複合あり。
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</BaseLayout>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,0 +1,14 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro'
+---
+
+<BaseLayout title="Projects">
+  <div class="mx-auto max-w-[780px] px-4 py-8 sm:px-6 md:px-8">
+    <h1 class="mb-6 text-2xl font-bold">Projects</h1>
+    <ul class="list-disc pl-6">
+      <li>
+        <a href="/projects/bms" class="text-blue-500 hover:underline">BMS</a>
+      </li>
+    </ul>
+  </div>
+</BaseLayout>


### PR DESCRIPTION
## Why

- from: https://github.com/fohte/fohte.net/pull/405

## What

- Reimplement `/projects`, `/projects/bms`, `/privacy-policy` with Astro + Tailwind CSS

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/fohte.net/pull/422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
