### PR TITLE
astro: integrate Google Analytics (GA4)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -10,6 +10,16 @@ interface Props {
 const { title = 'fohte.net' } = Astro.props
 
 const siteTitle = title === 'fohte.net' ? title : `${title} - fohte.net`
+
+const GA_ID = 'G-RGKPSR5QL5'
+const gaScript = `
+<script src="https://www.googletagmanager.com/gtag/js?id=${GA_ID}" async></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '${GA_ID}');
+</script>`
 ---
 
 <!doctype html>
@@ -19,6 +29,7 @@ const siteTitle = title === 'fohte.net' ? title : `${title} - fohte.net`
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/icon.png" />
     <title>{siteTitle}</title>
+    {import.meta.env.PROD && <Fragment set:html={gaScript} />}
   </head>
   <body class="flex min-h-screen flex-col bg-gray-50">
     <Header />


### PR DESCRIPTION
## Why

- from: https://github.com/fohte/fohte.net/pull/405

## What

- Add GA4 gtag.js script to `BaseLayout.astro`, loaded only in production (`import.meta.env.PROD`)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/fohte.net/pull/423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
