### PR TITLE
astro: add Atom feed endpoint

### DIFF
--- a/src/pages/feed.atom.ts
+++ b/src/pages/feed.atom.ts
@@ -1,0 +1,58 @@
+import mdxRenderer from '@astrojs/mdx/server.js'
+import reactRenderer from '@astrojs/react/server.js'
+import type { APIRoute } from 'astro'
+import { experimental_AstroContainer } from 'astro/container'
+import { render } from 'astro:content'
+import { Feed } from 'feed'
+
+import { rssComponents } from '@/components/mdx'
+import { getAllPosts, getPostUrl } from '@/utils/posts'
+
+const SITE_URL = 'https://fohte.net'
+
+async function renderPostToHtml(
+  post: Awaited<ReturnType<typeof getAllPosts>>[number],
+): Promise<string> {
+  const container = await experimental_AstroContainer.create()
+  container.addServerRenderer({ renderer: reactRenderer })
+  container.addServerRenderer({ renderer: mdxRenderer })
+
+  const { Content } = await render(post)
+  const html = await container.renderToString(Content, {
+    props: { components: rssComponents },
+  })
+
+  return html
+}
+
+export const GET: APIRoute = async () => {
+  const feed = new Feed({
+    title: 'fohte.net',
+    id: `${SITE_URL}/`,
+    link: `${SITE_URL}/`,
+    favicon: `${SITE_URL}/icon.png`,
+    copyright: 'All rights reserved 2020, Fohte (Hayato Kawai)',
+    feed: `${SITE_URL}/feed.atom`,
+  })
+
+  const posts = await getAllPosts()
+
+  for (const post of posts.slice(0, 10)) {
+    const content = await renderPostToHtml(post)
+    feed.addItem({
+      title: post.data.title,
+      author: [{ name: 'Fohte (Hayato Kawai)', link: `${SITE_URL}/` }],
+      content,
+      date: post.data.date,
+      published: post.data.date,
+      description: post.data.description,
+      link: `${SITE_URL}${getPostUrl(post)}`,
+    })
+  }
+
+  return new Response(feed.atom1(), {
+    headers: {
+      'Content-Type': 'application/atom+xml; charset=utf-8',
+    },
+  })
+}

--- a/src/pages/feed.atom.ts
+++ b/src/pages/feed.atom.ts
@@ -1,6 +1,8 @@
 import mdxRenderer from '@astrojs/mdx/server.js'
 import reactRenderer from '@astrojs/react/server.js'
 import type { APIRoute } from 'astro'
+// experimental API: track https://docs.astro.build/en/reference/container-reference/
+// for stable alternatives
 import { experimental_AstroContainer } from 'astro/container'
 import { render } from 'astro:content'
 import { Feed } from 'feed'
@@ -9,21 +11,6 @@ import { rssComponents } from '@/components/mdx'
 import { getAllPosts, getPostUrl } from '@/utils/posts'
 
 const SITE_URL = 'https://fohte.net'
-
-async function renderPostToHtml(
-  post: Awaited<ReturnType<typeof getAllPosts>>[number],
-): Promise<string> {
-  const container = await experimental_AstroContainer.create()
-  container.addServerRenderer({ renderer: reactRenderer })
-  container.addServerRenderer({ renderer: mdxRenderer })
-
-  const { Content } = await render(post)
-  const html = await container.renderToString(Content, {
-    props: { components: rssComponents },
-  })
-
-  return html
-}
 
 export const GET: APIRoute = async () => {
   const feed = new Feed({
@@ -36,13 +23,26 @@ export const GET: APIRoute = async () => {
   })
 
   const posts = await getAllPosts()
+  const latestPosts = posts.slice(0, 10)
 
-  for (const post of posts.slice(0, 10)) {
-    const content = await renderPostToHtml(post)
+  const container = await experimental_AstroContainer.create()
+  container.addServerRenderer({ renderer: reactRenderer })
+  container.addServerRenderer({ renderer: mdxRenderer })
+
+  const renderedContents = await Promise.all(
+    latestPosts.map(async (post) => {
+      const { Content } = await render(post)
+      return container.renderToString(Content, {
+        props: { components: rssComponents },
+      })
+    }),
+  )
+
+  for (const [i, post] of latestPosts.entries()) {
     feed.addItem({
       title: post.data.title,
       author: [{ name: 'Fohte (Hayato Kawai)', link: `${SITE_URL}/` }],
-      content,
+      content: renderedContents[i],
       date: post.data.date,
       published: post.data.date,
       description: post.data.description,


### PR DESCRIPTION
## Why

- from: https://github.com/fohte/fohte.net/pull/405

## What

- Implement `/feed.atom` as an Astro static endpoint, serving the latest 10 blog posts as an Atom feed
- Render MDX content to HTML using the Astro Container API with simplified `rssComponents` for custom components

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/fohte.net/pull/424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
