### PR TITLE
astro: add OG/Twitter meta tags and Atom feed link

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,6 +9,7 @@ import remarkGfm from 'remark-gfm'
 import remarkUnwrapImages from 'remark-unwrap-images'
 
 export default defineConfig({
+  site: 'https://fohte.net',
   integrations: [
     react(),
     embeds({

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -8,6 +8,7 @@ interface Props {
   description?: string
   ogType?: string
   ogImage?: string
+  twitterCreator?: string
   fediverseCreator?: string
 }
 
@@ -16,6 +17,7 @@ const {
   description,
   ogType = 'website',
   ogImage,
+  twitterCreator = '@fohte',
   fediverseCreator,
 } = Astro.props
 
@@ -57,9 +59,12 @@ const gaScript = `
     {!ogImage && <meta property="og:image:height" content="500" />}
     {description && <meta property="og:description" content={description} />}
 
-    <meta name="twitter:card" content="summary" />
+    <meta
+      name="twitter:card"
+      content={ogImage ? 'summary_large_image' : 'summary'}
+    />
     <meta name="twitter:site" content="@fohte" />
-    <meta name="twitter:creator" content="@fohte" />
+    <meta name="twitter:creator" content={twitterCreator} />
 
     {
       fediverseCreator && (

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,11 +5,26 @@ import '../styles/global.css'
 
 interface Props {
   title?: string
+  description?: string
+  ogType?: string
+  ogImage?: string
+  fediverseCreator?: string
 }
 
-const { title = 'fohte.net' } = Astro.props
+const {
+  title = 'fohte.net',
+  description,
+  ogType = 'website',
+  ogImage,
+  fediverseCreator,
+} = Astro.props
 
 const siteTitle = title === 'fohte.net' ? title : `${title} - fohte.net`
+const canonicalUrl = Astro.url.href
+const defaultOgImage = new URL('/icon.png', Astro.site).href
+const resolvedOgImage = ogImage
+  ? new URL(ogImage, Astro.site).href
+  : defaultOgImage
 
 const GA_ID = 'G-RGKPSR5QL5'
 const gaScript = `
@@ -29,6 +44,36 @@ const gaScript = `
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/icon.png" />
     <title>{siteTitle}</title>
+
+    {description && <meta name="description" content={description} />}
+
+    <meta property="og:title" content={siteTitle} />
+    <meta property="og:site_name" content="fohte.net" />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:type" content={ogType} />
+    <meta property="og:locale" content="ja_JP" />
+    <meta property="og:image" content={resolvedOgImage} />
+    {!ogImage && <meta property="og:image:width" content="500" />}
+    {!ogImage && <meta property="og:image:height" content="500" />}
+    {description && <meta property="og:description" content={description} />}
+
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:site" content="@fohte" />
+    <meta name="twitter:creator" content="@fohte" />
+
+    {
+      fediverseCreator && (
+        <meta name="fediverse:creator" content={fediverseCreator} />
+      )
+    }
+
+    <link
+      rel="alternate"
+      type="application/atom+xml"
+      title="fohte.net"
+      href="/feed.atom"
+    />
+
     {import.meta.env.PROD && <Fragment set:html={gaScript} />}
   </head>
   <body class="flex min-h-screen flex-col bg-gray-50">

--- a/src/pages/blog/posts/[slug].astro
+++ b/src/pages/blog/posts/[slug].astro
@@ -19,7 +19,13 @@ const { Content } = await render(post)
 const formattedDate = format(post.data.date, 'yyyy-MM-dd')
 ---
 
-<BaseLayout title={post.data.title}>
+<BaseLayout
+  title={post.data.title}
+  description={post.data.description}
+  ogType="article"
+  ogImage={post.data.imagePath}
+  fediverseCreator="@fohte@social.fohte.net"
+>
   <article class="mx-auto max-w-[780px] bg-white px-4 py-8 sm:px-6 md:px-8">
     <header class="mb-8">
       <time


### PR DESCRIPTION
## Why

- from: https://github.com/fohte/fohte.net/pull/405
- OG meta tags, Twitter Card meta tags, and the Atom feed `<link rel="alternate">` are missing on all pages in the Astro migration, breaking SNS link previews and browser/RSS reader feed auto-discovery

## What

- Add OG/Twitter meta tags and an Atom feed link to `BaseLayout.astro` to match the metadata output of the Next.js version
- Article pages override `og:type=article`, description, and `fediverse:creator`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/fohte.net/pull/425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
