### PR TITLE
mdx: fix heading ## prefix being duplicated on text wrap

### DIFF
--- a/src/components/mdx/DocsHeading.tsx
+++ b/src/components/mdx/DocsHeading.tsx
@@ -23,11 +23,11 @@ export const DocsHeading: React.FC<DocsHeadingProps> = ({
       className={[baseStyles, defaultMb, className].filter(Boolean).join(' ')}
       {...props}
     >
-      <span className="flex items-center gap-2">
-        <span className="text-[13px] font-bold text-[var(--color-accent)]">
+      <span className="flex items-baseline gap-2">
+        <span className="shrink-0 text-[13px] font-bold text-[var(--color-accent)]">
           {'#'.repeat(Number(Component.replace('h', '')) || 2)}
         </span>
-        <span>{children}</span>
+        <span className="min-w-0">{children}</span>
         {id && (
           <a
             href={`#${id}`}


### PR DESCRIPTION
## Why

- Heading (h2/h3) `##` prefix appeared duplicated on each line when the heading text wrapped to multiple lines

## What

- Heading prefix (`##`) is displayed only once regardless of text wrapping

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/fohte.net/pull/436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
