### PR TITLE
toc: fix heading indentation and exclude footnotes from ToC

### DIFF
--- a/src/components/astro/TocList.astro
+++ b/src/components/astro/TocList.astro
@@ -1,0 +1,28 @@
+---
+interface Props {
+  headings: { depth: number; slug: string; text: string }[]
+}
+
+const { headings } = Astro.props
+---
+
+<ul class="flex flex-col gap-2">
+  {
+    headings.map((heading) => (
+      <li
+        style={
+          heading.depth > 1
+            ? `padding-left: ${(heading.depth - 1) * 12}px`
+            : undefined
+        }
+      >
+        <a
+          href={`#${heading.slug}`}
+          class="text-text-secondary hover:text-accent font-[family-name:var(--font-mono-ui)] text-[13px] no-underline transition-colors"
+        >
+          {heading.text}
+        </a>
+      </li>
+    ))
+  }
+</ul>

--- a/src/pages/blog/posts/[slug].astro
+++ b/src/pages/blog/posts/[slug].astro
@@ -18,7 +18,9 @@ export async function getStaticPaths() {
 const { post } = Astro.props
 const { Content, headings } = await render(post)
 const formattedDate = format(post.data.date, 'yyyy-MM-dd')
-const tocHeadings = headings.filter((h) => h.depth <= 3)
+const tocHeadings = headings.filter(
+  (h) => h.depth <= 3 && h.slug !== 'footnote-label',
+)
 const ogImage = post.data.imagePath || `/og/${post.id}.png`
 ---
 

--- a/src/pages/blog/posts/[slug].astro
+++ b/src/pages/blog/posts/[slug].astro
@@ -4,6 +4,7 @@ import { format } from 'date-fns'
 
 import BaseLayout from '@/layouts/BaseLayout.astro'
 import Tag from '@/components/astro/Tag.astro'
+import TocList from '@/components/astro/TocList.astro'
 import { mdxComponents } from '@/components/mdx'
 
 export async function getStaticPaths() {
@@ -71,24 +72,7 @@ const ogImage = post.data.imagePath || `/og/${post.id}.png`
                 // table of contents
               </summary>
               <nav class="mt-3">
-                <ul class="flex flex-col gap-2">
-                  {tocHeadings.map((heading) => (
-                    <li
-                      style={
-                        heading.depth > 1
-                          ? `padding-left: ${(heading.depth - 1) * 12}px`
-                          : undefined
-                      }
-                    >
-                      <a
-                        href={`#${heading.slug}`}
-                        class="text-text-secondary hover:text-accent font-[family-name:var(--font-mono-ui)] text-[13px] no-underline transition-colors"
-                      >
-                        {heading.text}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
+                <TocList headings={tocHeadings} />
               </nav>
             </details>
           </div>
@@ -134,24 +118,7 @@ const ogImage = post.data.imagePath || `/og/${post.id}.png`
             // table of contents
           </span>
           <nav>
-            <ul class="flex flex-col gap-2">
-              {tocHeadings.map((heading) => (
-                <li
-                  style={
-                    heading.depth > 1
-                      ? `padding-left: ${(heading.depth - 1) * 12}px`
-                      : undefined
-                  }
-                >
-                  <a
-                    href={`#${heading.slug}`}
-                    class="text-text-secondary hover:text-accent font-[family-name:var(--font-mono-ui)] text-[13px] no-underline transition-colors"
-                  >
-                    {heading.text}
-                  </a>
-                </li>
-              ))}
-            </ul>
+            <TocList headings={tocHeadings} />
           </nav>
         </aside>
       )

--- a/src/pages/blog/posts/[slug].astro
+++ b/src/pages/blog/posts/[slug].astro
@@ -75,8 +75,8 @@ const ogImage = post.data.imagePath || `/og/${post.id}.png`
                   {tocHeadings.map((heading) => (
                     <li
                       style={
-                        heading.depth > 2
-                          ? `padding-left: ${(heading.depth - 2) * 12}px`
+                        heading.depth > 1
+                          ? `padding-left: ${(heading.depth - 1) * 12}px`
                           : undefined
                       }
                     >
@@ -138,8 +138,8 @@ const ogImage = post.data.imagePath || `/og/${post.id}.png`
               {tocHeadings.map((heading) => (
                 <li
                   style={
-                    heading.depth > 2
-                      ? `padding-left: ${(heading.depth - 2) * 12}px`
+                    heading.depth > 1
+                      ? `padding-left: ${(heading.depth - 1) * 12}px`
                       : undefined
                   }
                 >


### PR DESCRIPTION
## Why

- ToC heading indentation did not reflect the h1/h2/h3 hierarchy — h1 and h2 were displayed at the same level
- remark-gfm auto-generated "Footnotes" heading appeared in the ToC despite being visually hidden

## What

- Apply `padding-left` based on heading `depth` so the hierarchy is visually distinguishable (h1=0px, h2=12px, h3=24px)
- Exclude the `footnote-label` heading from ToC entries
- Extract shared ToC list rendering into a `TocList` component