### PR TITLE
redirects: add redirects from old Hugo URLs to current paths

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -6,3 +6,15 @@
 /projects/bms/locker(F).bms https://assets.fohte.net/projects/bms/locker(F).bms 301
 /projects/bms/Scafohld.zip https://assets.fohte.net/projects/bms/Scafohld.zip 301
 /blog/posts/2023-10-02-twitter-to-mastodon /blog/posts/2023-12-02-twitter-to-mastodon 301
+
+# Redirect old Hugo URLs (/blog/YYYY/MM/DD/slug/) to current paths (/blog/posts/YYYY-MM-DD-slug/)
+/blog/2018/11/06/hello-hugo /blog/posts/2018-11-06-hello-hugo/ 301
+/blog/2018/11/06/hello-hugo/ /blog/posts/2018-11-06-hello-hugo/ 301
+/blog/2019/07/15/build-helix-keyboard-kit /blog/posts/2019-07-15-build-helix-keyboard-kit/ 301
+/blog/2019/07/15/build-helix-keyboard-kit/ /blog/posts/2019-07-15-build-helix-keyboard-kit/ 301
+/blog/2020/06/07/next-js-mdx /blog/posts/2020-06-07-next-js-mdx/ 301
+/blog/2020/06/07/next-js-mdx/ /blog/posts/2020-06-07-next-js-mdx/ 301
+/blog/2022/05/16/the-3rd-abear-cup /blog/posts/2022-05-16-the-3rd-abear-cup/ 301
+/blog/2022/05/16/the-3rd-abear-cup/ /blog/posts/2022-05-16-the-3rd-abear-cup/ 301
+/blog/2023/03/20/job-transition /blog/posts/2023-03-20-job-transition/ 301
+/blog/2023/03/20/job-transition/ /blog/posts/2023-03-20-job-transition/ 301

--- a/public/_redirects
+++ b/public/_redirects
@@ -9,12 +9,7 @@
 
 # Redirect old Hugo URLs (/blog/YYYY/MM/DD/slug/) to current paths (/blog/posts/YYYY-MM-DD-slug/)
 /blog/2018/11/06/hello-hugo /blog/posts/2018-11-06-hello-hugo/ 301
-/blog/2018/11/06/hello-hugo/ /blog/posts/2018-11-06-hello-hugo/ 301
 /blog/2019/07/15/build-helix-keyboard-kit /blog/posts/2019-07-15-build-helix-keyboard-kit/ 301
-/blog/2019/07/15/build-helix-keyboard-kit/ /blog/posts/2019-07-15-build-helix-keyboard-kit/ 301
 /blog/2020/06/07/next-js-mdx /blog/posts/2020-06-07-next-js-mdx/ 301
-/blog/2020/06/07/next-js-mdx/ /blog/posts/2020-06-07-next-js-mdx/ 301
 /blog/2022/05/16/the-3rd-abear-cup /blog/posts/2022-05-16-the-3rd-abear-cup/ 301
-/blog/2022/05/16/the-3rd-abear-cup/ /blog/posts/2022-05-16-the-3rd-abear-cup/ 301
 /blog/2023/03/20/job-transition /blog/posts/2023-03-20-job-transition/ 301
-/blog/2023/03/20/job-transition/ /blog/posts/2023-03-20-job-transition/ 301

--- a/public/_redirects
+++ b/public/_redirects
@@ -9,7 +9,12 @@
 
 # Redirect old Hugo URLs (/blog/YYYY/MM/DD/slug/) to current paths (/blog/posts/YYYY-MM-DD-slug/)
 /blog/2018/11/06/hello-hugo /blog/posts/2018-11-06-hello-hugo/ 301
+/blog/2018/11/06/hello-hugo/ /blog/posts/2018-11-06-hello-hugo/ 301
 /blog/2019/07/15/build-helix-keyboard-kit /blog/posts/2019-07-15-build-helix-keyboard-kit/ 301
+/blog/2019/07/15/build-helix-keyboard-kit/ /blog/posts/2019-07-15-build-helix-keyboard-kit/ 301
 /blog/2020/06/07/next-js-mdx /blog/posts/2020-06-07-next-js-mdx/ 301
+/blog/2020/06/07/next-js-mdx/ /blog/posts/2020-06-07-next-js-mdx/ 301
 /blog/2022/05/16/the-3rd-abear-cup /blog/posts/2022-05-16-the-3rd-abear-cup/ 301
+/blog/2022/05/16/the-3rd-abear-cup/ /blog/posts/2022-05-16-the-3rd-abear-cup/ 301
 /blog/2023/03/20/job-transition /blog/posts/2023-03-20-job-transition/ 301
+/blog/2023/03/20/job-transition/ /blog/posts/2023-03-20-job-transition/ 301

--- a/public/_redirects
+++ b/public/_redirects
@@ -12,9 +12,3 @@
 /blog/2018/11/06/hello-hugo/ /blog/posts/2018-11-06-hello-hugo/ 301
 /blog/2019/07/15/build-helix-keyboard-kit /blog/posts/2019-07-15-build-helix-keyboard-kit/ 301
 /blog/2019/07/15/build-helix-keyboard-kit/ /blog/posts/2019-07-15-build-helix-keyboard-kit/ 301
-/blog/2020/06/07/next-js-mdx /blog/posts/2020-06-07-next-js-mdx/ 301
-/blog/2020/06/07/next-js-mdx/ /blog/posts/2020-06-07-next-js-mdx/ 301
-/blog/2022/05/16/the-3rd-abear-cup /blog/posts/2022-05-16-the-3rd-abear-cup/ 301
-/blog/2022/05/16/the-3rd-abear-cup/ /blog/posts/2022-05-16-the-3rd-abear-cup/ 301
-/blog/2023/03/20/job-transition /blog/posts/2023-03-20-job-transition/ 301
-/blog/2023/03/20/job-transition/ /blog/posts/2023-03-20-job-transition/ 301

--- a/public/_redirects
+++ b/public/_redirects
@@ -12,3 +12,15 @@
 /blog/2018/11/06/hello-hugo/ /blog/posts/2018-11-06-hello-hugo/ 301
 /blog/2019/07/15/build-helix-keyboard-kit /blog/posts/2019-07-15-build-helix-keyboard-kit/ 301
 /blog/2019/07/15/build-helix-keyboard-kit/ /blog/posts/2019-07-15-build-helix-keyboard-kit/ 301
+
+# Redirect old /blog/:slug paths to /blog/posts/:slug (changed in PR #22)
+/blog/2018-11-06-hello-hugo /blog/posts/2018-11-06-hello-hugo/ 301
+/blog/2018-11-06-hello-hugo/ /blog/posts/2018-11-06-hello-hugo/ 301
+/blog/2019-07-15-build-helix-keyboard-kit /blog/posts/2019-07-15-build-helix-keyboard-kit/ 301
+/blog/2019-07-15-build-helix-keyboard-kit/ /blog/posts/2019-07-15-build-helix-keyboard-kit/ 301
+/blog/2020-06-07-next-js-mdx /blog/posts/2020-06-07-next-js-mdx/ 301
+/blog/2020-06-07-next-js-mdx/ /blog/posts/2020-06-07-next-js-mdx/ 301
+/blog/2022-05-16-the-3rd-abear-cup /blog/posts/2022-05-16-the-3rd-abear-cup/ 301
+/blog/2022-05-16-the-3rd-abear-cup/ /blog/posts/2022-05-16-the-3rd-abear-cup/ 301
+/blog/2023-03-20-job-transition /blog/posts/2023-03-20-job-transition/ 301
+/blog/2023-03-20-job-transition/ /blog/posts/2023-03-20-job-transition/ 301


### PR DESCRIPTION
## Why

- Old URL paths from previous URL schemes return 404
  - External backlinks and search engine indexes still reference these old URLs
  - Two URL migrations happened without setting up redirects:
    1. Hugo → Next.js (2020-05-31): `/blog/YYYY/MM/DD/slug/` → `/blog/YYYY-MM-DD-slug` (2 posts)
    2. `/blog/:slug` → `/blog/posts/:slug` in https://github.com/fohte/fohte.net/pull/22 (5 posts)

## What

- Add 301 redirects for both old URL patterns to current URLs (`/blog/posts/YYYY-MM-DD-slug/`) in `_redirects`
  - Hugo-era URLs: 2 posts (`hello-hugo`, `build-helix-keyboard-kit`)
  - `/blog/:slug` URLs: all 5 posts that existed when the path was changed
  - Both trailing slash and non-trailing slash variants are listed, as `_redirects` rules match URLs exactly
    - Verified with the existing rule `/blog/posts/2023-10-02-twitter-to-mastodon` (non-trailing slash only) — trailing slash variant was not redirected:
      ```console
      $ curl -s -o /dev/null -w '%{http_code} %{redirect_url}' 'https://fohte.net/blog/posts/2023-10-02-twitter-to-mastodon'
      301 https://fohte.net/blog/posts/2023-12-02-twitter-to-mastodon
      $ curl -s -o /dev/null -w '%{http_code} %{redirect_url}' 'https://fohte.net/blog/posts/2023-10-02-twitter-to-mastodon/'
      200
      ```