### PR TITLE
astro: normalize URLs to remove trailing slashes

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -58,6 +58,7 @@ function transformerFilename() {
 
 export default defineConfig({
   site: 'https://fohte.net',
+  trailingSlash: 'never',
   integrations: [
     react(),
     embeds({

--- a/public/_redirects
+++ b/public/_redirects
@@ -8,19 +8,19 @@
 /blog/posts/2023-10-02-twitter-to-mastodon /blog/posts/2023-12-02-twitter-to-mastodon 301
 
 # Redirect old Hugo URLs (/blog/YYYY/MM/DD/slug/) to current paths (/blog/posts/YYYY-MM-DD-slug/)
-/blog/2018/11/06/hello-hugo /blog/posts/2018-11-06-hello-hugo/ 301
-/blog/2018/11/06/hello-hugo/ /blog/posts/2018-11-06-hello-hugo/ 301
-/blog/2019/07/15/build-helix-keyboard-kit /blog/posts/2019-07-15-build-helix-keyboard-kit/ 301
-/blog/2019/07/15/build-helix-keyboard-kit/ /blog/posts/2019-07-15-build-helix-keyboard-kit/ 301
+/blog/2018/11/06/hello-hugo /blog/posts/2018-11-06-hello-hugo 301
+/blog/2018/11/06/hello-hugo/ /blog/posts/2018-11-06-hello-hugo 301
+/blog/2019/07/15/build-helix-keyboard-kit /blog/posts/2019-07-15-build-helix-keyboard-kit 301
+/blog/2019/07/15/build-helix-keyboard-kit/ /blog/posts/2019-07-15-build-helix-keyboard-kit 301
 
 # Redirect old /blog/:slug paths to /blog/posts/:slug (changed in PR #22)
-/blog/2018-11-06-hello-hugo /blog/posts/2018-11-06-hello-hugo/ 301
-/blog/2018-11-06-hello-hugo/ /blog/posts/2018-11-06-hello-hugo/ 301
-/blog/2019-07-15-build-helix-keyboard-kit /blog/posts/2019-07-15-build-helix-keyboard-kit/ 301
-/blog/2019-07-15-build-helix-keyboard-kit/ /blog/posts/2019-07-15-build-helix-keyboard-kit/ 301
-/blog/2020-06-07-next-js-mdx /blog/posts/2020-06-07-next-js-mdx/ 301
-/blog/2020-06-07-next-js-mdx/ /blog/posts/2020-06-07-next-js-mdx/ 301
-/blog/2022-05-16-the-3rd-abear-cup /blog/posts/2022-05-16-the-3rd-abear-cup/ 301
-/blog/2022-05-16-the-3rd-abear-cup/ /blog/posts/2022-05-16-the-3rd-abear-cup/ 301
-/blog/2023-03-20-job-transition /blog/posts/2023-03-20-job-transition/ 301
-/blog/2023-03-20-job-transition/ /blog/posts/2023-03-20-job-transition/ 301
+/blog/2018-11-06-hello-hugo /blog/posts/2018-11-06-hello-hugo 301
+/blog/2018-11-06-hello-hugo/ /blog/posts/2018-11-06-hello-hugo 301
+/blog/2019-07-15-build-helix-keyboard-kit /blog/posts/2019-07-15-build-helix-keyboard-kit 301
+/blog/2019-07-15-build-helix-keyboard-kit/ /blog/posts/2019-07-15-build-helix-keyboard-kit 301
+/blog/2020-06-07-next-js-mdx /blog/posts/2020-06-07-next-js-mdx 301
+/blog/2020-06-07-next-js-mdx/ /blog/posts/2020-06-07-next-js-mdx 301
+/blog/2022-05-16-the-3rd-abear-cup /blog/posts/2022-05-16-the-3rd-abear-cup 301
+/blog/2022-05-16-the-3rd-abear-cup/ /blog/posts/2022-05-16-the-3rd-abear-cup 301
+/blog/2023-03-20-job-transition /blog/posts/2023-03-20-job-transition 301
+/blog/2023-03-20-job-transition/ /blog/posts/2023-03-20-job-transition 301


### PR DESCRIPTION
## Why

- GA4 counts URLs with and without trailing slashes as separate pages, splitting pageviews

## What

- Set `trailingSlash: "never"` in Astro config to normalize all URLs without trailing slashes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/fohte.net/pull/445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
