### PR TITLE
astro: set `build.format: 'file'` to eliminate trailing slash redirects

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -60,6 +60,9 @@ function transformerFilename() {
 export default defineConfig({
   site: 'https://fohte.net',
   trailingSlash: 'never',
+  build: {
+    format: 'file',
+  },
   integrations: [
     react(),
     embeds({


### PR DESCRIPTION
## Why

- from: https://github.com/fohte/fohte.net/pull/445
- The previous PR set `trailingSlash: 'never'`, but Cloudflare Pages still issues 308 redirects to trailing-slash URLs
  - Astro's `trailingSlash` only affects route matching in dev server/SSR, not the static build output format
  - Cloudflare Pages redirects `slug/index.html` to `/slug/` (with trailing slash), while `slug.html` is served as `/slug` (without trailing slash)

## What

- Add `build.format: 'file'` to change build output from `slug/index.html` to `slug.html`

### Verification (preview build)

| URL | Production (before) | Preview (after) |
|---|---|---|
| `/blog` | 308 → `/blog/` | **200** |
| `/blog/` | 200 | 308 → `/blog` |
| `/blog/posts/2018-11-06-hello-hugo` | 308 → `.../hello-hugo/` | **200** |
| `/blog/posts/2018-11-06-hello-hugo/` | 200 | 308 → `.../hello-hugo` |