### PR TITLE
eslint: add pre-commit hook and fix existing lint errors

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+
 import mdx from '@astrojs/mdx'
 import react from '@astrojs/react'
 import sitemap from '@astrojs/sitemap'

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,12 @@ const config = [
     ignores: ['dist/**/*', '.astro/**/*'],
   },
   {
+    files: ['**/*.cjs'],
+    rules: {
+      '@typescript-eslint/no-var-requires': 'off',
+    },
+  },
+  {
     rules: {
       'no-restricted-imports': [
         'error',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,7 @@ const config = [
     ignores: ['dist/**/*', '.astro/**/*'],
   },
   {
+    // .cjs files use CommonJS, so require() is the correct module system
     files: ['**/*.cjs'],
     rules: {
       '@typescript-eslint/no-var-requires': 'off',

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,3 +3,9 @@ remotes:
     ref: v0.1.15 # renovate: datasource=github-tags depName=fohte/lefthook-config
     configs:
       - base.yml
+
+pre-commit:
+  commands:
+    eslint:
+      glob: '*.{js,ts,jsx,tsx,mjs,cjs,astro}'
+      run: bun x eslint {staged_files}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- vite version mismatch between @vitejs/plugin-react and vitest
   plugins: [react() as any],
   test: {
     environment: 'happy-dom',


### PR DESCRIPTION
## Why

- ESLint was not included in the pre-commit hook or CI, allowing lint errors to go undetected

## What

- Add an ESLint command to the lefthook pre-commit hook to lint staged files
- Fix existing lint errors
  - `astro.config.mjs`: reorder imports to comply with `simple-import-sort` rules
  - `eslint.config.js`: disable `@typescript-eslint/no-var-requires` for `.cjs` files, as `require()` is the correct module system for CommonJS
  - `vitest.config.ts`: add an eslint-disable comment for the `as any` cast caused by a vite version mismatch

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/fohte.net/pull/453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
