### PR TITLE
lib: Add MDX text extraction and content hash utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,14 +31,19 @@
     "date-fns": "4.1.0",
     "feed": "4.2.2",
     "gray-matter": "4.0.3",
+    "mdast-util-to-string": "4.0.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "remark-breaks": "4.0.0",
     "remark-gfm": "4.0.1",
+    "remark-mdx": "3.1.1",
+    "remark-parse": "11.0.0",
     "remark-unwrap-images": "4.0.1",
     "satori": "0.25.0",
     "sharp": "0.34.5",
-    "tailwindcss": "4.1.18"
+    "tailwindcss": "4.1.18",
+    "unified": "11.0.5",
+    "unist-util-visit": "5.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "20.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       gray-matter:
         specifier: 4.0.3
         version: 4.0.3
+      mdast-util-to-string:
+        specifier: 4.0.0
+        version: 4.0.0
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -63,6 +66,12 @@ importers:
       remark-gfm:
         specifier: 4.0.1
         version: 4.0.1
+      remark-mdx:
+        specifier: 3.1.1
+        version: 3.1.1
+      remark-parse:
+        specifier: 11.0.0
+        version: 11.0.0
       remark-unwrap-images:
         specifier: 4.0.1
         version: 4.0.1
@@ -75,6 +84,12 @@ importers:
       tailwindcss:
         specifier: 4.1.18
         version: 4.1.18
+      unified:
+        specifier: 11.0.5
+        version: 11.0.5
+      unist-util-visit:
+        specifier: 5.1.0
+        version: 5.1.0
     devDependencies:
       '@commitlint/cli':
         specifier: 20.4.4

--- a/src/lib/mdx-text-extractor.test.ts
+++ b/src/lib/mdx-text-extractor.test.ts
@@ -37,9 +37,7 @@ const x = 1
 \`\`\`
 
 after`
-    expect(stripMarkdown(input)).toContain('before')
-    expect(stripMarkdown(input)).toContain('after')
-    expect(stripMarkdown(input)).not.toContain('const x = 1')
+    expect(stripMarkdown(input)).toBe('beforeafter')
   })
 
   it('removes self-closing JSX components', () => {
@@ -61,17 +59,12 @@ Hello world.`
     const input = `Some text[^1] here.
 
 [^1]: This is a footnote.`
-    const result = stripMarkdown(input)
-    expect(result).toContain('Some text')
-    expect(result).toContain('here.')
+    expect(stripMarkdown(input)).toBe('Some text here.This is a footnote.')
   })
 
   it('removes horizontal rules', () => {
     const input = `before\n\n---\n\nafter`
-    const result = stripMarkdown(input)
-    expect(result).toContain('before')
-    expect(result).toContain('after')
-    expect(result).not.toContain('---')
+    expect(stripMarkdown(input)).toBe('beforeafter')
   })
 })
 
@@ -89,11 +82,7 @@ This is **bold** text with a [link](https://example.com).
 `
     const result = extractTextFromMdx(mdx)
     expect(result.title).toBe('My Post Title')
-    expect(result.body).toContain('Introduction')
-    expect(result.body).toContain('This is bold text with a link.')
-    expect(result.body).not.toContain('##')
-    expect(result.body).not.toContain('**')
-    expect(result.body).not.toContain('https://example.com')
+    expect(result.body).toBe('IntroductionThis is bold text with a link.')
   })
 
   it('handles MDX without frontmatter title', () => {

--- a/src/lib/mdx-text-extractor.test.ts
+++ b/src/lib/mdx-text-extractor.test.ts
@@ -42,22 +42,12 @@ after`
     expect(stripMarkdown(input)).not.toContain('const x = 1')
   })
 
-  it('removes JSX components', () => {
+  it('removes self-closing JSX components', () => {
     expect(stripMarkdown('<CardLink href="https://example.com" />')).toBe('')
   })
 
-  it('removes block-level JSX with children', () => {
-    const input = `before
-
-<ImageGrid>
-  ![img1](a.png)
-  ![img2](b.png)
-</ImageGrid>
-
-after`
-    expect(stripMarkdown(input)).toContain('before')
-    expect(stripMarkdown(input)).toContain('after')
-    expect(stripMarkdown(input)).not.toContain('img1')
+  it('preserves text children of JSX components', () => {
+    expect(stripMarkdown('<Kbd>Ctrl</Kbd> + <Kbd>C</Kbd>')).toBe('Ctrl + C')
   })
 
   it('removes import/export statements', () => {

--- a/src/lib/mdx-text-extractor.test.ts
+++ b/src/lib/mdx-text-extractor.test.ts
@@ -37,7 +37,7 @@ const x = 1
 \`\`\`
 
 after`
-    expect(stripMarkdown(input)).toBe('beforeafter')
+    expect(stripMarkdown(input)).toBe('before\n\nafter')
   })
 
   it('removes self-closing JSX components', () => {
@@ -59,12 +59,12 @@ Hello world.`
     const input = `Some text[^1] here.
 
 [^1]: This is a footnote.`
-    expect(stripMarkdown(input)).toBe('Some text here.This is a footnote.')
+    expect(stripMarkdown(input)).toBe('Some text here.\n\nThis is a footnote.')
   })
 
   it('removes horizontal rules', () => {
     const input = `before\n\n---\n\nafter`
-    expect(stripMarkdown(input)).toBe('beforeafter')
+    expect(stripMarkdown(input)).toBe('before\n\nafter')
   })
 })
 
@@ -82,7 +82,7 @@ This is **bold** text with a [link](https://example.com).
 `
     const result = extractTextFromMdx(mdx)
     expect(result.title).toBe('My Post Title')
-    expect(result.body).toBe('IntroductionThis is bold text with a link.')
+    expect(result.body).toBe('Introduction\n\nThis is bold text with a link.')
   })
 
   it('handles MDX without frontmatter title', () => {

--- a/src/lib/mdx-text-extractor.test.ts
+++ b/src/lib/mdx-text-extractor.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  computeContentHash,
+  extractTextFromMdx,
+  stripMarkdown,
+} from '@/lib/mdx-text-extractor'
+
+describe('stripMarkdown', () => {
+  it('removes heading markers', () => {
+    expect(stripMarkdown('## Hello World')).toBe('Hello World')
+  })
+
+  it('removes bold and italic markers', () => {
+    expect(stripMarkdown('**bold** and *italic*')).toBe('bold and italic')
+  })
+
+  it('converts links to plain text', () => {
+    expect(stripMarkdown('[click here](https://example.com)')).toBe(
+      'click here',
+    )
+  })
+
+  it('removes images', () => {
+    expect(stripMarkdown('![alt text](image.png)')).toBe('')
+  })
+
+  it('removes inline code', () => {
+    expect(stripMarkdown('use `git push` to deploy')).toBe('use  to deploy')
+  })
+
+  it('removes fenced code blocks', () => {
+    const input = `before
+
+\`\`\`js
+const x = 1
+\`\`\`
+
+after`
+    expect(stripMarkdown(input)).toBe('before\n\nafter')
+  })
+
+  it('removes HTML/JSX tags', () => {
+    expect(stripMarkdown('<CardLink href="https://example.com" />')).toBe('')
+    expect(stripMarkdown('<div>content</div>')).toBe('content')
+  })
+
+  it('removes footnote references and definitions', () => {
+    const input = `Some text[^1] here.
+
+[^1]: This is a footnote.`
+    const result = stripMarkdown(input)
+    expect(result).toContain('Some text here.')
+    expect(result).not.toContain('[^1]')
+  })
+
+  it('removes horizontal rules', () => {
+    const input = `before\n\n---\n\nafter`
+    expect(stripMarkdown(input)).toBe('before\n\nafter')
+  })
+})
+
+describe('extractTextFromMdx', () => {
+  it('extracts title from frontmatter and strips body', () => {
+    const mdx = `---
+title: 'My Post Title'
+date: '2024-01-01'
+tags: [test]
+---
+
+## Introduction
+
+This is **bold** text with a [link](https://example.com).
+`
+    const result = extractTextFromMdx(mdx)
+    expect(result.title).toBe('My Post Title')
+    expect(result.body).toContain('Introduction')
+    expect(result.body).toContain('This is bold text with a link.')
+    expect(result.body).not.toContain('##')
+    expect(result.body).not.toContain('**')
+    expect(result.body).not.toContain('https://example.com')
+  })
+
+  it('handles MDX without frontmatter title', () => {
+    const mdx = `---
+date: '2024-01-01'
+---
+
+Hello world.
+`
+    const result = extractTextFromMdx(mdx)
+    expect(result.title).toBe('')
+    expect(result.body).toBe('Hello world.')
+  })
+
+  it('removes all frontmatter fields from body', () => {
+    const mdx = `---
+title: 'Test'
+date: '2024-01-01'
+description: 'A description'
+tags: [a, b]
+imagePath: '/img.png'
+---
+
+Body content here.
+`
+    const result = extractTextFromMdx(mdx)
+    expect(result.body).not.toContain('description')
+    expect(result.body).not.toContain('imagePath')
+    expect(result.body).toBe('Body content here.')
+  })
+
+  it('handles Japanese content', () => {
+    const mdx = `---
+title: 'ブログ始めました'
+date: '2024-01-01'
+---
+
+これは**テスト**です。
+`
+    const result = extractTextFromMdx(mdx)
+    expect(result.title).toBe('ブログ始めました')
+    expect(result.body).toBe('これはテストです。')
+  })
+})
+
+describe('computeContentHash', () => {
+  it('produces a cache key in model:hash format', () => {
+    const hash = computeContentHash('hello world')
+    expect(hash).toMatch(/^voyage-4:[a-f0-9]{64}$/)
+  })
+
+  it('returns the same hash for the same content', () => {
+    const a = computeContentHash('identical content')
+    const b = computeContentHash('identical content')
+    expect(a).toBe(b)
+  })
+
+  it('returns different hashes for different content', () => {
+    const a = computeContentHash('content A')
+    const b = computeContentHash('content B')
+    expect(a).not.toBe(b)
+  })
+
+  it('uses a custom model name in the cache key', () => {
+    const hash = computeContentHash('test', 'voyage-3')
+    expect(hash).toMatch(/^voyage-3:[a-f0-9]{64}$/)
+  })
+
+  it('changes when model name changes even with same content', () => {
+    const a = computeContentHash('same content', 'voyage-4')
+    const b = computeContentHash('same content', 'voyage-3')
+    expect(a).not.toBe(b)
+  })
+})

--- a/src/lib/mdx-text-extractor.test.ts
+++ b/src/lib/mdx-text-extractor.test.ts
@@ -37,26 +37,51 @@ const x = 1
 \`\`\`
 
 after`
-    expect(stripMarkdown(input)).toBe('before\n\nafter')
+    expect(stripMarkdown(input)).toContain('before')
+    expect(stripMarkdown(input)).toContain('after')
+    expect(stripMarkdown(input)).not.toContain('const x = 1')
   })
 
-  it('removes HTML/JSX tags', () => {
+  it('removes JSX components', () => {
     expect(stripMarkdown('<CardLink href="https://example.com" />')).toBe('')
-    expect(stripMarkdown('<div>content</div>')).toBe('content')
   })
 
-  it('removes footnote references and definitions', () => {
+  it('removes block-level JSX with children', () => {
+    const input = `before
+
+<ImageGrid>
+  ![img1](a.png)
+  ![img2](b.png)
+</ImageGrid>
+
+after`
+    expect(stripMarkdown(input)).toContain('before')
+    expect(stripMarkdown(input)).toContain('after')
+    expect(stripMarkdown(input)).not.toContain('img1')
+  })
+
+  it('removes import/export statements', () => {
+    const input = `import { Foo } from './foo'
+
+Hello world.`
+    expect(stripMarkdown(input)).toBe('Hello world.')
+  })
+
+  it('removes footnote references', () => {
     const input = `Some text[^1] here.
 
 [^1]: This is a footnote.`
     const result = stripMarkdown(input)
-    expect(result).toContain('Some text here.')
-    expect(result).not.toContain('[^1]')
+    expect(result).toContain('Some text')
+    expect(result).toContain('here.')
   })
 
   it('removes horizontal rules', () => {
     const input = `before\n\n---\n\nafter`
-    expect(stripMarkdown(input)).toBe('before\n\nafter')
+    const result = stripMarkdown(input)
+    expect(result).toContain('before')
+    expect(result).toContain('after')
+    expect(result).not.toContain('---')
   })
 })
 

--- a/src/lib/mdx-text-extractor.ts
+++ b/src/lib/mdx-text-extractor.ts
@@ -1,0 +1,82 @@
+import { createHash } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+
+import matter from 'gray-matter'
+
+/**
+ * MDX file content parsed into title and plain text body.
+ */
+export interface ExtractedText {
+  title: string
+  body: string
+}
+
+/**
+ * Strip Markdown / MDX syntax to produce plain text.
+ *
+ * Handles: headings, bold/italic, links, images, inline code, code blocks,
+ * HTML/JSX tags, footnote references, and footnote definitions.
+ */
+export function stripMarkdown(md: string): string {
+  return (
+    md
+      // Remove fenced code blocks (``` ... ```)
+      .replace(/^```[\s\S]*?^```/gm, '')
+      // Remove inline code
+      .replace(/`[^`]+`/g, '')
+      // Remove images ![alt](url)
+      .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+      // Convert links [text](url) to text
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+      // Remove HTML/JSX tags (including self-closing like <CardLink ... />)
+      .replace(/<[^>]+\/?>/g, '')
+      // Remove heading markers
+      .replace(/^#{1,6}\s+/gm, '')
+      // Remove bold/italic markers
+      .replace(/(\*{1,3}|_{1,3})([^*_]+)\1/g, '$2')
+      // Remove footnote references [^name]
+      .replace(/\[\^[^\]]+\]/g, '')
+      // Remove footnote definitions at line start
+      .replace(/^\[\^[^\]]+\]:\s*/gm, '')
+      // Remove horizontal rules
+      .replace(/^[-*_]{3,}\s*$/gm, '')
+      // Collapse multiple blank lines
+      .replace(/\n{3,}/g, '\n\n')
+      .trim()
+  )
+}
+
+/**
+ * Parse an MDX string and extract the title (from frontmatter) and
+ * the body as plain text (Markdown syntax stripped).
+ */
+export function extractTextFromMdx(mdxContent: string): ExtractedText {
+  const { data, content } = matter(mdxContent)
+  const title = typeof data.title === 'string' ? data.title : ''
+  const body = stripMarkdown(content)
+  return { title, body }
+}
+
+/**
+ * Read an MDX file from disk and extract its text content.
+ */
+export async function extractTextFromFile(
+  filePath: string,
+): Promise<ExtractedText> {
+  const raw = await readFile(filePath, 'utf-8')
+  return extractTextFromMdx(raw)
+}
+
+/**
+ * Compute a cache key combining the embedding model name and a SHA-256 hash
+ * of the content text.
+ *
+ * Format: `<model>:<sha256hex>`
+ */
+export function computeContentHash(
+  text: string,
+  model: string = 'voyage-4',
+): string {
+  const hash = createHash('sha256').update(text, 'utf-8').digest('hex')
+  return `${model}:${hash}`
+}

--- a/src/lib/mdx-text-extractor.ts
+++ b/src/lib/mdx-text-extractor.ts
@@ -45,7 +45,13 @@ export function stripMarkdown(md: string): string {
     }
   })
 
-  return toString(tree).trim()
+  // Join top-level blocks with newlines to preserve paragraph separation
+  const blocks = 'children' in tree ? (tree.children as unknown[]) : [tree]
+  return blocks
+    .map((node) => toString(node))
+    .filter((text) => text.length > 0)
+    .join('\n\n')
+    .trim()
 }
 
 /**

--- a/src/lib/mdx-text-extractor.ts
+++ b/src/lib/mdx-text-extractor.ts
@@ -16,6 +16,17 @@ export interface ExtractedText {
 
 const processor = unified().use(remarkParse).use(remarkMdx).use(remarkGfm)
 
+// Node types that don't contribute meaningful text for embedding
+const nodeTypesToRemove = new Set([
+  'mdxjsEsm', // import/export statements
+  'mdxFlowExpression', // {expressions}
+  'mdxTextExpression', // inline {expressions}
+  'code', // fenced code blocks
+  'inlineCode', // inline code
+  'image', // images
+  'html', // raw HTML
+])
+
 /**
  * Parse Markdown/MDX content and extract plain text.
  * JSX components are kept so that text children (e.g. `<Kbd>Ctrl</Kbd>`)
@@ -26,15 +37,7 @@ export function stripMarkdown(md: string): string {
   const tree = processor.parse(md)
 
   visit(tree, (node, index, parent) => {
-    if (
-      node.type === 'mdxjsEsm' || // import/export statements
-      node.type === 'mdxFlowExpression' || // {expressions}
-      node.type === 'mdxTextExpression' || // inline {expressions}
-      node.type === 'code' || // fenced code blocks
-      node.type === 'inlineCode' || // inline code
-      node.type === 'image' || // images
-      node.type === 'html' // raw HTML
-    ) {
+    if (nodeTypesToRemove.has(node.type)) {
       if (parent && typeof index === 'number') {
         parent.children.splice(index, 1)
         return [SKIP, index]

--- a/src/lib/mdx-text-extractor.ts
+++ b/src/lib/mdx-text-extractor.ts
@@ -2,53 +2,53 @@ import { createHash } from 'node:crypto'
 import { readFile } from 'node:fs/promises'
 
 import matter from 'gray-matter'
+import { toString } from 'mdast-util-to-string'
+import remarkGfm from 'remark-gfm'
+import remarkMdx from 'remark-mdx'
+import remarkParse from 'remark-parse'
+import { unified } from 'unified'
+import { SKIP, visit } from 'unist-util-visit'
 
-/**
- * MDX file content parsed into title and plain text body.
- */
 export interface ExtractedText {
   title: string
   body: string
 }
 
+const processor = unified().use(remarkParse).use(remarkMdx).use(remarkGfm)
+
 /**
- * Strip Markdown / MDX syntax to produce plain text.
- *
- * Handles: headings, bold/italic, links, images, inline code, code blocks,
- * HTML/JSX tags, footnote references, and footnote definitions.
+ * Parse Markdown/MDX content and extract plain text,
+ * removing JSX elements, import/export statements, and code blocks.
  */
 export function stripMarkdown(md: string): string {
-  return (
-    md
-      // Remove fenced code blocks (``` ... ```)
-      .replace(/^```[\s\S]*?^```/gm, '')
-      // Remove inline code
-      .replace(/`[^`]+`/g, '')
-      // Remove images ![alt](url)
-      .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
-      // Convert links [text](url) to text
-      .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
-      // Remove HTML/JSX tags (including self-closing like <CardLink ... />)
-      .replace(/<[^>]+\/?>/g, '')
-      // Remove heading markers
-      .replace(/^#{1,6}\s+/gm, '')
-      // Remove bold/italic markers
-      .replace(/(\*{1,3}|_{1,3})([^*_]+)\1/g, '$2')
-      // Remove footnote references [^name]
-      .replace(/\[\^[^\]]+\]/g, '')
-      // Remove footnote definitions at line start
-      .replace(/^\[\^[^\]]+\]:\s*/gm, '')
-      // Remove horizontal rules
-      .replace(/^[-*_]{3,}\s*$/gm, '')
-      // Collapse multiple blank lines
-      .replace(/\n{3,}/g, '\n\n')
-      .trim()
-  )
+  const tree = processor.parse(md)
+
+  // Remove nodes that don't contribute meaningful text
+  visit(tree, (node, index, parent) => {
+    if (
+      node.type === 'mdxjsEsm' || // import/export statements
+      node.type === 'mdxJsxFlowElement' || // block-level JSX like <CardLink />
+      node.type === 'mdxJsxTextElement' || // inline JSX
+      node.type === 'mdxFlowExpression' || // {expressions}
+      node.type === 'mdxTextExpression' || // inline {expressions}
+      node.type === 'code' || // fenced code blocks
+      node.type === 'inlineCode' || // inline code
+      node.type === 'image' || // images
+      node.type === 'html' // raw HTML
+    ) {
+      if (parent && typeof index === 'number') {
+        parent.children.splice(index, 1)
+        return [SKIP, index]
+      }
+    }
+  })
+
+  return toString(tree).trim()
 }
 
 /**
  * Parse an MDX string and extract the title (from frontmatter) and
- * the body as plain text (Markdown syntax stripped).
+ * the body as plain text.
  */
 export function extractTextFromMdx(mdxContent: string): ExtractedText {
   const { data, content } = matter(mdxContent)

--- a/src/lib/mdx-text-extractor.ts
+++ b/src/lib/mdx-text-extractor.ts
@@ -17,18 +17,17 @@ export interface ExtractedText {
 const processor = unified().use(remarkParse).use(remarkMdx).use(remarkGfm)
 
 /**
- * Parse Markdown/MDX content and extract plain text,
- * removing JSX elements, import/export statements, and code blocks.
+ * Parse Markdown/MDX content and extract plain text.
+ * JSX components are kept so that text children (e.g. `<Kbd>Ctrl</Kbd>`)
+ * are preserved by `toString`. Only non-text nodes like import/export
+ * statements, code blocks, and images are removed.
  */
 export function stripMarkdown(md: string): string {
   const tree = processor.parse(md)
 
-  // Remove nodes that don't contribute meaningful text
   visit(tree, (node, index, parent) => {
     if (
       node.type === 'mdxjsEsm' || // import/export statements
-      node.type === 'mdxJsxFlowElement' || // block-level JSX like <CardLink />
-      node.type === 'mdxJsxTextElement' || // inline JSX
       node.type === 'mdxFlowExpression' || // {expressions}
       node.type === 'mdxTextExpression' || // inline {expressions}
       node.type === 'code' || // fenced code blocks


### PR DESCRIPTION
## Why

- The embedding-based related posts feature requires a utility to extract plain text from MDX article files and compute content hashes

## What

- Add a utility in `src/lib/mdx-text-extractor.ts` that parses MDX into an AST via `unified` + `remark-parse` + `remark-mdx` + `remark-gfm`, then extracts plain text using `mdast-util-to-string`
  - Text children of JSX components (e.g. `<Kbd>Ctrl</Kbd>`) are preserved, while import/export statements, code blocks, and images are removed
  - The SHA-256 content hash uses a cache key format including the model name (`voyage-4:<SHA-256>`), used for embedding cache invalidation in subsequent tasks

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/fohte.net/pull/457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
