### PR TITLE
lib: Add Voyage AI embedding client module

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "sharp": "0.34.5",
     "tailwindcss": "4.1.18",
     "unified": "11.0.5",
-    "unist-util-visit": "5.1.0"
+    "unist-util-visit": "5.1.0",
+    "voyageai": "0.2.1"
   },
   "devDependencies": {
     "@commitlint/cli": "20.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       unist-util-visit:
         specifier: 5.1.0
         version: 5.1.0
+      voyageai:
+        specifier: 0.2.1
+        version: 0.2.1
     devDependencies:
       '@commitlint/cli':
         specifier: 20.4.4
@@ -5903,6 +5906,18 @@ packages:
         integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==,
       }
 
+  node-fetch@2.7.0:
+    resolution:
+      {
+        integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==,
+      }
+    engines: { node: 4.x || >=6.0.0 }
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-localstorage@2.2.1:
     resolution:
       {
@@ -7517,6 +7532,12 @@ packages:
       }
     engines: { node: '>=16' }
 
+  tr46@0.0.3:
+    resolution:
+      {
+        integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==,
+      }
+
   tr46@5.1.1:
     resolution:
       {
@@ -8037,6 +8058,21 @@ packages:
       jsdom:
         optional: true
 
+  voyageai@0.2.1:
+    resolution:
+      {
+        integrity: sha512-ym7Dk6p8Si6lR9wDh58EzxwT0ziD/pqXjzzzceOSySO3Ic3uosHZLOTAsb3Gq+1OaKdEMnni/p8TohKUNvLTkg==,
+      }
+    engines: { node: '>=18.0.0' }
+    peerDependencies:
+      '@huggingface/transformers': ^3.8.0
+      onnxruntime-node: '>=1.17.0'
+    peerDependenciesMeta:
+      '@huggingface/transformers':
+        optional: true
+      onnxruntime-node:
+        optional: true
+
   w3c-xmlserializer@5.0.0:
     resolution:
       {
@@ -8054,6 +8090,12 @@ packages:
     resolution:
       {
         integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==,
+      }
+
+  webidl-conversions@3.0.1:
+    resolution:
+      {
+        integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==,
       }
 
   webidl-conversions@7.0.0:
@@ -8091,6 +8133,12 @@ packages:
         integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==,
       }
     engines: { node: '>=18' }
+
+  whatwg-url@5.0.0:
+    resolution:
+      {
+        integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==,
+      }
 
   which-boxed-primitive@1.1.1:
     resolution:
@@ -12267,6 +12315,10 @@ snapshots:
 
   node-fetch-native@1.6.7: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-localstorage@2.2.1:
     dependencies:
       write-file-atomic: 1.3.4
@@ -13445,6 +13497,8 @@ snapshots:
     dependencies:
       tldts: 6.1.86
 
+  tr46@0.0.3: {}
+
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
@@ -13788,6 +13842,12 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  voyageai@0.2.1:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
@@ -13795,6 +13855,8 @@ snapshots:
   web-namespaces@1.1.4: {}
 
   web-namespaces@2.0.1: {}
+
+  webidl-conversions@3.0.1: {}
 
   webidl-conversions@7.0.0: {}
 
@@ -13810,6 +13872,11 @@ snapshots:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/src/lib/voyage-embeddings.test.ts
+++ b/src/lib/voyage-embeddings.test.ts
@@ -148,7 +148,7 @@ describe('generateEmbeddings', () => {
     warnSpy.mockRestore()
   })
 
-  it('returns embedding vectors for multiple texts', async () => {
+  it('returns embedding vectors and total tokens for multiple texts', async () => {
     const vectors = [makeVector(), makeVector()]
     mockEmbed.mockResolvedValueOnce(makeEmbedResponse(vectors, 100))
 
@@ -156,9 +156,10 @@ describe('generateEmbeddings', () => {
       apiKey: 'test-key',
     })
 
-    expect(result).toHaveLength(2)
-    expect(result?.[0].vector).toEqual(vectors[0])
-    expect(result?.[1].vector).toEqual(vectors[1])
+    expect(result).toEqual({
+      embeddings: vectors,
+      totalTokens: 100,
+    })
     expect(mockEmbed).toHaveBeenCalledWith(
       {
         input: ['text1', 'text2'],
@@ -176,10 +177,10 @@ describe('generateEmbeddings', () => {
     expect(warnSpy).toHaveBeenCalled()
   })
 
-  it('returns an empty array for empty input', async () => {
+  it('returns empty embeddings for empty input', async () => {
     const result = await generateEmbeddings([], { apiKey: 'test-key' })
 
-    expect(result).toEqual([])
+    expect(result).toEqual({ embeddings: [], totalTokens: 0 })
     expect(mockEmbed).not.toHaveBeenCalled()
   })
 

--- a/src/lib/voyage-embeddings.test.ts
+++ b/src/lib/voyage-embeddings.test.ts
@@ -1,0 +1,205 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest'
+
+import { generateEmbedding, generateEmbeddings } from '@/lib/voyage-embeddings'
+
+// Mock the VoyageAIClient
+const mockEmbed = vi.fn()
+
+vi.mock('voyageai', () => {
+  return {
+    VoyageAIClient: class {
+      embed = mockEmbed
+    },
+  }
+})
+
+function makeVector(dimensions: number = 1024): number[] {
+  return Array.from({ length: dimensions }, (_, i) => i * 0.001)
+}
+
+function makeEmbedResponse(
+  vectors: number[][],
+  totalTokens: number = 42,
+): {
+  data: Array<{ object: string; embedding: number[]; index: number }>
+  usage: { totalTokens: number }
+} {
+  return {
+    data: vectors.map((embedding, index) => ({
+      object: 'embedding',
+      embedding,
+      index,
+    })),
+    usage: { totalTokens },
+  }
+}
+
+describe('generateEmbedding', () => {
+  let warnSpy: MockInstance
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('returns an embedding vector on success', async () => {
+    const vector = makeVector()
+    mockEmbed.mockResolvedValueOnce(makeEmbedResponse([vector], 42))
+
+    const result = await generateEmbedding('hello world', {
+      apiKey: 'test-key',
+    })
+
+    expect(result).toEqual({
+      vector,
+      totalTokens: 42,
+    })
+    expect(mockEmbed).toHaveBeenCalledWith(
+      {
+        input: 'hello world',
+        model: 'voyage-4',
+        inputType: 'document',
+      },
+      { maxRetries: 3 },
+    )
+  })
+
+  it('returns null and warns when API key is not set', async () => {
+    const result = await generateEmbedding('hello world', { apiKey: '' })
+
+    expect(result).toBeNull()
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('VOYAGE_API_KEY is not set'),
+    )
+    expect(mockEmbed).not.toHaveBeenCalled()
+  })
+
+  it('returns null when apiKey option is undefined and env var is unset', async () => {
+    const original = process.env.VOYAGE_API_KEY
+    delete process.env.VOYAGE_API_KEY
+
+    const result = await generateEmbedding('hello world')
+
+    expect(result).toBeNull()
+    expect(warnSpy).toHaveBeenCalled()
+
+    if (original !== undefined) {
+      process.env.VOYAGE_API_KEY = original
+    }
+  })
+
+  it('throws when API response has no embeddings', async () => {
+    mockEmbed.mockResolvedValueOnce({ data: [], usage: { totalTokens: 0 } })
+
+    await expect(
+      generateEmbedding('hello', { apiKey: 'test-key' }),
+    ).rejects.toThrow('did not contain an embedding vector')
+  })
+
+  it('throws when dimensions do not match expected value', async () => {
+    mockEmbed.mockResolvedValueOnce(makeEmbedResponse([makeVector(512)], 10))
+
+    await expect(
+      generateEmbedding('hello', { apiKey: 'test-key' }),
+    ).rejects.toThrow('Expected 1024 dimensions but got 512')
+  })
+
+  it('passes maxRetries: 3 to the SDK for exponential backoff', async () => {
+    mockEmbed.mockResolvedValueOnce(makeEmbedResponse([makeVector()], 10))
+
+    await generateEmbedding('hello', { apiKey: 'test-key' })
+
+    expect(mockEmbed).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ maxRetries: 3 }),
+    )
+  })
+
+  it('propagates SDK errors', async () => {
+    mockEmbed.mockRejectedValueOnce(new Error('rate limit exceeded'))
+
+    await expect(
+      generateEmbedding('hello', { apiKey: 'test-key' }),
+    ).rejects.toThrow('rate limit exceeded')
+  })
+})
+
+describe('generateEmbeddings', () => {
+  let warnSpy: MockInstance
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('returns embedding vectors for multiple texts', async () => {
+    const vectors = [makeVector(), makeVector()]
+    mockEmbed.mockResolvedValueOnce(makeEmbedResponse(vectors, 100))
+
+    const result = await generateEmbeddings(['text1', 'text2'], {
+      apiKey: 'test-key',
+    })
+
+    expect(result).toHaveLength(2)
+    expect(result?.[0].vector).toEqual(vectors[0])
+    expect(result?.[1].vector).toEqual(vectors[1])
+    expect(mockEmbed).toHaveBeenCalledWith(
+      {
+        input: ['text1', 'text2'],
+        model: 'voyage-4',
+        inputType: 'document',
+      },
+      { maxRetries: 3 },
+    )
+  })
+
+  it('returns null when API key is not set', async () => {
+    const result = await generateEmbeddings(['text'], { apiKey: '' })
+
+    expect(result).toBeNull()
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it('returns an empty array for empty input', async () => {
+    const result = await generateEmbeddings([], { apiKey: 'test-key' })
+
+    expect(result).toEqual([])
+    expect(mockEmbed).not.toHaveBeenCalled()
+  })
+
+  it('throws when response count does not match input count', async () => {
+    mockEmbed.mockResolvedValueOnce(makeEmbedResponse([makeVector()], 10))
+
+    await expect(
+      generateEmbeddings(['text1', 'text2'], { apiKey: 'test-key' }),
+    ).rejects.toThrow('Expected 2 embeddings but got 1')
+  })
+
+  it('throws when any embedding has wrong dimensions', async () => {
+    mockEmbed.mockResolvedValueOnce(
+      makeEmbedResponse([makeVector(1024), makeVector(512)], 20),
+    )
+
+    await expect(
+      generateEmbeddings(['text1', 'text2'], { apiKey: 'test-key' }),
+    ).rejects.toThrow(
+      'Embedding at index 1: expected 1024 dimensions but got 512',
+    )
+  })
+})

--- a/src/lib/voyage-embeddings.ts
+++ b/src/lib/voyage-embeddings.ts
@@ -1,0 +1,150 @@
+import { VoyageAIClient } from 'voyageai'
+
+const EMBEDDING_MODEL = 'voyage-4'
+const EXPECTED_DIMENSIONS = 1024
+const MAX_RETRIES = 3
+
+export interface EmbeddingResult {
+  /** The embedding vector */
+  vector: number[]
+  /** Total tokens consumed by this request */
+  totalTokens: number
+}
+
+interface EmbedResponseItem {
+  embedding?: number[]
+}
+
+interface EmbedResponse {
+  data?: EmbedResponseItem[]
+  usage?: { totalTokens?: number }
+}
+
+function extractEmbeddings(response: EmbedResponse): number[][] | undefined {
+  const data = response.data
+  if (data == null || data.length === 0) {
+    return undefined
+  }
+
+  const vectors: number[][] = []
+  for (const item of data) {
+    if (item.embedding == null) {
+      return undefined
+    }
+    vectors.push(item.embedding)
+  }
+  return vectors
+}
+
+function extractTotalTokens(response: EmbedResponse): number {
+  return response.usage?.totalTokens ?? 0
+}
+
+/**
+ * Generate an embedding vector for the given text using Voyage AI.
+ *
+ * Returns `null` when the API key is not configured, logging a warning
+ * instead of failing so the build can continue with cached data.
+ */
+export async function generateEmbedding(
+  text: string,
+  options?: { apiKey?: string },
+): Promise<EmbeddingResult | null> {
+  const apiKey = options?.apiKey ?? process.env.VOYAGE_API_KEY
+
+  if (apiKey == null || apiKey === '') {
+    console.warn(
+      '[voyage-embeddings] VOYAGE_API_KEY is not set. Skipping embedding generation.',
+    )
+    return null
+  }
+
+  const client = new VoyageAIClient({ apiKey })
+
+  const response: EmbedResponse = await client.embed(
+    {
+      input: text,
+      model: EMBEDDING_MODEL,
+      inputType: 'document',
+    },
+    {
+      maxRetries: MAX_RETRIES,
+    },
+  )
+
+  const embeddings = extractEmbeddings(response)
+  if (embeddings == null || embeddings.length === 0) {
+    throw new Error(
+      '[voyage-embeddings] API response did not contain an embedding vector.',
+    )
+  }
+
+  const vector = embeddings[0]
+  if (vector.length !== EXPECTED_DIMENSIONS) {
+    throw new Error(
+      `[voyage-embeddings] Expected ${String(EXPECTED_DIMENSIONS)} dimensions but got ${String(vector.length)}.`,
+    )
+  }
+
+  return {
+    vector,
+    totalTokens: extractTotalTokens(response),
+  }
+}
+
+/**
+ * Generate embedding vectors for multiple texts in a single API call.
+ *
+ * Returns `null` when the API key is not configured.
+ */
+export async function generateEmbeddings(
+  texts: string[],
+  options?: { apiKey?: string },
+): Promise<EmbeddingResult[] | null> {
+  const apiKey = options?.apiKey ?? process.env.VOYAGE_API_KEY
+
+  if (apiKey == null || apiKey === '') {
+    console.warn(
+      '[voyage-embeddings] VOYAGE_API_KEY is not set. Skipping embedding generation.',
+    )
+    return null
+  }
+
+  if (texts.length === 0) {
+    return []
+  }
+
+  const client = new VoyageAIClient({ apiKey })
+
+  const response: EmbedResponse = await client.embed(
+    {
+      input: texts,
+      model: EMBEDDING_MODEL,
+      inputType: 'document',
+    },
+    {
+      maxRetries: MAX_RETRIES,
+    },
+  )
+
+  const embeddings = extractEmbeddings(response)
+  if (embeddings == null || embeddings.length !== texts.length) {
+    throw new Error(
+      `[voyage-embeddings] Expected ${String(texts.length)} embeddings but got ${String(embeddings?.length ?? 0)}.`,
+    )
+  }
+
+  for (let i = 0; i < embeddings.length; i++) {
+    if (embeddings[i].length !== EXPECTED_DIMENSIONS) {
+      throw new Error(
+        `[voyage-embeddings] Embedding at index ${String(i)}: expected ${String(EXPECTED_DIMENSIONS)} dimensions but got ${String(embeddings[i].length)}.`,
+      )
+    }
+  }
+
+  const totalTokens = extractTotalTokens(response)
+  return embeddings.map((vector) => ({
+    vector,
+    totalTokens: Math.round(totalTokens / texts.length),
+  }))
+}

--- a/src/lib/voyage-embeddings.ts
+++ b/src/lib/voyage-embeddings.ts
@@ -145,6 +145,6 @@ export async function generateEmbeddings(
   const totalTokens = extractTotalTokens(response)
   return embeddings.map((vector) => ({
     vector,
-    totalTokens: Math.round(totalTokens / texts.length),
+    totalTokens,
   }))
 }

--- a/src/lib/voyage-embeddings.ts
+++ b/src/lib/voyage-embeddings.ts
@@ -7,7 +7,14 @@ const MAX_RETRIES = 3
 export interface EmbeddingResult {
   /** The embedding vector */
   vector: number[]
-  /** Total tokens consumed by the entire API request (shared across batch results) */
+  /** Total tokens consumed by this API request */
+  totalTokens: number
+}
+
+export interface BatchEmbeddingResult {
+  /** Embedding vectors, one per input text */
+  embeddings: number[][]
+  /** Total tokens consumed by the entire batch API request */
   totalTokens: number
 }
 
@@ -100,7 +107,7 @@ export async function generateEmbedding(
 export async function generateEmbeddings(
   texts: string[],
   options?: { apiKey?: string },
-): Promise<EmbeddingResult[] | null> {
+): Promise<BatchEmbeddingResult | null> {
   const apiKey = options?.apiKey ?? process.env.VOYAGE_API_KEY
 
   if (apiKey == null || apiKey === '') {
@@ -111,7 +118,7 @@ export async function generateEmbeddings(
   }
 
   if (texts.length === 0) {
-    return []
+    return { embeddings: [], totalTokens: 0 }
   }
 
   const client = new VoyageAIClient({ apiKey })
@@ -142,9 +149,8 @@ export async function generateEmbeddings(
     }
   }
 
-  const totalTokens = extractTotalTokens(response)
-  return embeddings.map((vector) => ({
-    vector,
-    totalTokens,
-  }))
+  return {
+    embeddings,
+    totalTokens: extractTotalTokens(response),
+  }
 }

--- a/src/lib/voyage-embeddings.ts
+++ b/src/lib/voyage-embeddings.ts
@@ -7,7 +7,7 @@ const MAX_RETRIES = 3
 export interface EmbeddingResult {
   /** The embedding vector */
   vector: number[]
-  /** Total tokens consumed by this request */
+  /** Total tokens consumed by the entire API request (shared across batch results) */
   totalTokens: number
 }
 


### PR DESCRIPTION
## Why

- Part of the embedding-based related posts recommendation feature for the blog — a client module is needed to call the Voyage AI API and retrieve embedding vectors from article text

## What

- Add functions to generate embeddings using the Voyage AI `voyage-4` model
    - Provide both single-text (`generateEmbedding`) and batch (`generateEmbeddings`) functions
- Skip API calls with a warning when the API key is not configured (builds can continue using cached data)
- Use the SDK's built-in exponential backoff retry (up to 3 attempts, covering 429/5xx)
- Validate response vector dimensions (1024)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/fohte.net/pull/459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
