### PR TITLE
lib: Add embedding cache module for `.vec` file read/write

### DIFF
--- a/src/lib/embedding-cache.test.ts
+++ b/src/lib/embedding-cache.test.ts
@@ -1,0 +1,281 @@
+import { existsSync } from 'node:fs'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest'
+
+import {
+  getOrCreateEmbedding,
+  readEmbeddingCache,
+  writeEmbeddingCache,
+} from '@/lib/embedding-cache'
+
+function makeVector(dimensions: number = 1024): number[] {
+  return Array.from({ length: dimensions }, (_, i) => i * 0.001)
+}
+
+function makeCacheFileContent(cacheKey: string, vector: number[]): string {
+  return [cacheKey, ...vector.map(String)].join('\n') + '\n'
+}
+
+describe('readEmbeddingCache', () => {
+  let tmpDir: string
+  let warnSpy: MockInstance
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), 'embedding-cache-test-'))
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(async () => {
+    warnSpy.mockRestore()
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns the vector when cache key matches', async () => {
+    const vector = makeVector()
+    const cacheKey = 'voyage-4:abc123'
+    await writeFile(
+      path.join(tmpDir, 'my-post.vec'),
+      makeCacheFileContent(cacheKey, vector),
+      'utf-8',
+    )
+
+    const result = await readEmbeddingCache('my-post', cacheKey, tmpDir)
+
+    expect(result).toEqual(vector)
+  })
+
+  it('returns null when file does not exist', async () => {
+    const result = await readEmbeddingCache('missing', 'voyage-4:abc', tmpDir)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null when cache key does not match', async () => {
+    const vector = makeVector()
+    await writeFile(
+      path.join(tmpDir, 'my-post.vec'),
+      makeCacheFileContent('voyage-4:old-hash', vector),
+      'utf-8',
+    )
+
+    const result = await readEmbeddingCache(
+      'my-post',
+      'voyage-4:new-hash',
+      tmpDir,
+    )
+
+    expect(result).toBeNull()
+    // File should not be deleted on key mismatch
+    expect(existsSync(path.join(tmpDir, 'my-post.vec'))).toBe(true)
+  })
+
+  it('deletes corrupted file with wrong number of lines and returns null', async () => {
+    const filePath = path.join(tmpDir, 'broken.vec')
+    await writeFile(filePath, 'voyage-4:abc\n0.1\n0.2\n', 'utf-8')
+
+    const result = await readEmbeddingCache('broken', 'voyage-4:abc', tmpDir)
+
+    expect(result).toBeNull()
+    expect(existsSync(filePath)).toBe(false)
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Corrupted cache file'),
+    )
+  })
+
+  it('deletes corrupted file with non-numeric values and returns null', async () => {
+    const lines = [
+      'voyage-4:abc',
+      ...Array.from({ length: 1024 }, (_, i) =>
+        i === 500 ? 'not-a-number' : String(i * 0.001),
+      ),
+    ]
+    const filePath = path.join(tmpDir, 'bad-values.vec')
+    await writeFile(filePath, lines.join('\n') + '\n', 'utf-8')
+
+    const result = await readEmbeddingCache(
+      'bad-values',
+      'voyage-4:abc',
+      tmpDir,
+    )
+
+    expect(result).toBeNull()
+    expect(existsSync(filePath)).toBe(false)
+  })
+})
+
+describe('writeEmbeddingCache', () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), 'embedding-cache-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('creates the file with correct format', async () => {
+    const vector = makeVector()
+    const cacheKey = 'voyage-4:abc123'
+
+    await writeEmbeddingCache('my-post', cacheKey, vector, tmpDir)
+
+    const content = await readFile(path.join(tmpDir, 'my-post.vec'), 'utf-8')
+    expect(content).toBe(makeCacheFileContent(cacheKey, vector))
+  })
+
+  it('creates the directory if it does not exist', async () => {
+    const nestedDir = path.join(tmpDir, 'nested', 'dir')
+    const vector = makeVector()
+
+    await writeEmbeddingCache('post', 'voyage-4:abc', vector, nestedDir)
+
+    expect(existsSync(path.join(nestedDir, 'post.vec'))).toBe(true)
+  })
+})
+
+describe('getOrCreateEmbedding', () => {
+  let tmpDir: string
+  let warnSpy: MockInstance
+  const originalEnv = process.env.FORCE_REGENERATE_EMBEDDINGS
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), 'embedding-cache-test-'))
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    delete process.env.FORCE_REGENERATE_EMBEDDINGS
+  })
+
+  afterEach(async () => {
+    warnSpy.mockRestore()
+    await rm(tmpDir, { recursive: true, force: true })
+    if (originalEnv !== undefined) {
+      process.env.FORCE_REGENERATE_EMBEDDINGS = originalEnv
+    } else {
+      delete process.env.FORCE_REGENERATE_EMBEDDINGS
+    }
+  })
+
+  it('returns cached vector without calling generate on cache hit', async () => {
+    const vector = makeVector()
+    const cacheKey = 'voyage-4:abc'
+    await writeFile(
+      path.join(tmpDir, 'post.vec'),
+      makeCacheFileContent(cacheKey, vector),
+      'utf-8',
+    )
+
+    const generate = vi.fn()
+    const result = await getOrCreateEmbedding(
+      'post',
+      cacheKey,
+      generate,
+      tmpDir,
+    )
+
+    expect(result).toEqual(vector)
+    expect(generate).not.toHaveBeenCalled()
+  })
+
+  it('calls generate and writes cache on cache miss', async () => {
+    const vector = makeVector()
+    const generate = vi.fn().mockResolvedValueOnce(vector)
+
+    const result = await getOrCreateEmbedding(
+      'new-post',
+      'voyage-4:xyz',
+      generate,
+      tmpDir,
+    )
+
+    expect(result).toEqual(vector)
+    expect(generate).toHaveBeenCalledOnce()
+
+    const content = await readFile(path.join(tmpDir, 'new-post.vec'), 'utf-8')
+    expect(content).toBe(makeCacheFileContent('voyage-4:xyz', vector))
+  })
+
+  it('bypasses cache when FORCE_REGENERATE_EMBEDDINGS is true', async () => {
+    process.env.FORCE_REGENERATE_EMBEDDINGS = 'true'
+
+    // Write a valid cache file that should be bypassed
+    const oldVector = makeVector()
+    const cacheKey = 'voyage-4:abc'
+    await writeFile(
+      path.join(tmpDir, 'post.vec'),
+      makeCacheFileContent(cacheKey, oldVector),
+      'utf-8',
+    )
+
+    const newVector = Array.from({ length: 1024 }, () => 0.5)
+    const generate = vi.fn().mockResolvedValueOnce(newVector)
+
+    const result = await getOrCreateEmbedding(
+      'post',
+      cacheKey,
+      generate,
+      tmpDir,
+    )
+
+    expect(result).toEqual(newVector)
+    expect(generate).toHaveBeenCalledOnce()
+  })
+
+  it('does not bypass cache when FORCE_REGENERATE_EMBEDDINGS is not "true"', async () => {
+    process.env.FORCE_REGENERATE_EMBEDDINGS = 'false'
+
+    const vector = makeVector()
+    const cacheKey = 'voyage-4:abc'
+    await writeFile(
+      path.join(tmpDir, 'post.vec'),
+      makeCacheFileContent(cacheKey, vector),
+      'utf-8',
+    )
+
+    const generate = vi.fn()
+    const result = await getOrCreateEmbedding(
+      'post',
+      cacheKey,
+      generate,
+      tmpDir,
+    )
+
+    expect(result).toEqual(vector)
+    expect(generate).not.toHaveBeenCalled()
+  })
+
+  it('calls generate when cached file is corrupted', async () => {
+    // Write a corrupted file (wrong number of lines)
+    await writeFile(
+      path.join(tmpDir, 'corrupted.vec'),
+      'voyage-4:abc\n0.1\n',
+      'utf-8',
+    )
+
+    const vector = makeVector()
+    const generate = vi.fn().mockResolvedValueOnce(vector)
+
+    const result = await getOrCreateEmbedding(
+      'corrupted',
+      'voyage-4:abc',
+      generate,
+      tmpDir,
+    )
+
+    expect(result).toEqual(vector)
+    expect(generate).toHaveBeenCalledOnce()
+    // Corrupted file should be replaced with valid data
+    const content = await readFile(path.join(tmpDir, 'corrupted.vec'), 'utf-8')
+    expect(content).toBe(makeCacheFileContent('voyage-4:abc', vector))
+  })
+})

--- a/src/lib/embedding-cache.ts
+++ b/src/lib/embedding-cache.ts
@@ -1,0 +1,106 @@
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+const EXPECTED_DIMENSIONS = 1024
+
+export const DEFAULT_EMBEDDINGS_DIR = path.resolve('src/data/embeddings')
+
+/**
+ * Read a cached embedding vector from a .vec file.
+ *
+ * Returns the vector if the cache key matches, or `null` on cache miss,
+ * missing file, or corrupted data. Corrupted files are deleted automatically.
+ */
+export async function readEmbeddingCache(
+  slug: string,
+  expectedCacheKey: string,
+  embeddingsDir: string = DEFAULT_EMBEDDINGS_DIR,
+): Promise<number[] | null> {
+  const filePath = path.join(embeddingsDir, `${slug}.vec`)
+
+  let content: string
+  try {
+    content = await readFile(filePath, 'utf-8')
+  } catch {
+    return null
+  }
+
+  const lines = content.split('\n').filter((line) => line !== '')
+
+  // Validate structure: 1 cache key line + EXPECTED_DIMENSIONS float lines
+  if (lines.length !== EXPECTED_DIMENSIONS + 1) {
+    console.warn(
+      `[embedding-cache] Corrupted cache file for "${slug}" (expected ${String(EXPECTED_DIMENSIONS + 1)} lines, got ${String(lines.length)}). Deleting.`,
+    )
+    await rm(filePath, { force: true })
+    return null
+  }
+
+  const cacheKey = lines[0]
+
+  // Cache key mismatch — content or model changed
+  if (cacheKey !== expectedCacheKey) {
+    return null
+  }
+
+  const vector: number[] = []
+  for (let i = 1; i < lines.length; i++) {
+    const value = Number(lines[i])
+    if (!Number.isFinite(value)) {
+      console.warn(
+        `[embedding-cache] Corrupted cache file for "${slug}" (non-numeric value at line ${String(i + 1)}). Deleting.`,
+      )
+      await rm(filePath, { force: true })
+      return null
+    }
+    vector.push(value)
+  }
+
+  return vector
+}
+
+/**
+ * Write an embedding vector to a .vec cache file.
+ *
+ * Format: first line is the cache key, followed by one float per line.
+ */
+export async function writeEmbeddingCache(
+  slug: string,
+  cacheKey: string,
+  vector: number[],
+  embeddingsDir: string = DEFAULT_EMBEDDINGS_DIR,
+): Promise<void> {
+  await mkdir(embeddingsDir, { recursive: true })
+
+  const filePath = path.join(embeddingsDir, `${slug}.vec`)
+  const lines = [cacheKey, ...vector.map(String)]
+  await writeFile(filePath, lines.join('\n') + '\n', 'utf-8')
+}
+
+/**
+ * Get an embedding vector for a post, using the .vec file cache when possible.
+ *
+ * Cache logic:
+ * 1. If `FORCE_REGENERATE_EMBEDDINGS=true`, skip cache and call `generate`.
+ * 2. Try reading the cache file; if hit, return the cached vector.
+ * 3. On miss, call `generate` to obtain the vector, write it to cache, and return.
+ */
+export async function getOrCreateEmbedding(
+  slug: string,
+  cacheKey: string,
+  generate: () => Promise<number[]>,
+  embeddingsDir: string = DEFAULT_EMBEDDINGS_DIR,
+): Promise<number[]> {
+  const forceRegenerate = process.env.FORCE_REGENERATE_EMBEDDINGS === 'true'
+
+  if (!forceRegenerate) {
+    const cached = await readEmbeddingCache(slug, cacheKey, embeddingsDir)
+    if (cached != null) {
+      return cached
+    }
+  }
+
+  const vector = await generate()
+  await writeEmbeddingCache(slug, cacheKey, vector, embeddingsDir)
+  return vector
+}

--- a/src/lib/embedding-cache.ts
+++ b/src/lib/embedding-cache.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
-const EXPECTED_DIMENSIONS = 1024
+import { EXPECTED_DIMENSIONS } from '@/lib/embedding-constants'
 
 export const DEFAULT_EMBEDDINGS_DIR = path.resolve('src/data/embeddings')
 

--- a/src/lib/embedding-constants.ts
+++ b/src/lib/embedding-constants.ts
@@ -1,0 +1,2 @@
+export const EMBEDDING_MODEL = 'voyage-4'
+export const EXPECTED_DIMENSIONS = 1024

--- a/src/lib/voyage-embeddings.ts
+++ b/src/lib/voyage-embeddings.ts
@@ -1,7 +1,7 @@
 import { VoyageAIClient } from 'voyageai'
 
-const EMBEDDING_MODEL = 'voyage-4'
-const EXPECTED_DIMENSIONS = 1024
+import { EMBEDDING_MODEL, EXPECTED_DIMENSIONS } from '@/lib/embedding-constants'
+
 const MAX_RETRIES = 3
 
 export interface EmbeddingResult {


### PR DESCRIPTION
## Why

- Cache embedding vectors as `.vec` files per post to skip redundant Embedding API calls for unchanged content

## What

- Add a read/write module for `src/data/embeddings/<slug>.vec` files
- Store a cache key (`voyage-4:<SHA-256>` format) on the first line and float values (1024 dimensions) on subsequent lines
- Load embeddings from the file when the content hash matches the cache key; fetch via API and write to file on mismatch or missing file
- Support full cache invalidation via the `FORCE_REGENERATE_EMBEDDINGS=true` environment variable
- Auto-delete and re-fetch corrupted files (wrong line count or non-numeric values)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/fohte.net/pull/460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
