### PR TITLE
lib: Add cosine similarity and related posts selection module

### DIFF
--- a/src/lib/related-posts.test.ts
+++ b/src/lib/related-posts.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  cosineSimilarity,
+  findRelatedPosts,
+  type PostEmbedding,
+} from '@/lib/related-posts'
+
+describe('cosineSimilarity', () => {
+  it('returns 1 for identical unit vectors', () => {
+    const v = [1, 0, 0]
+    expect(cosineSimilarity(v, v)).toBeCloseTo(1)
+  })
+
+  it('returns 0 for orthogonal vectors', () => {
+    const a = [1, 0, 0]
+    const b = [0, 1, 0]
+    expect(cosineSimilarity(a, b)).toBeCloseTo(0)
+  })
+
+  it('returns 0 when either vector is a zero vector', () => {
+    const zero = [0, 0, 0]
+    const v = [1, 2, 3]
+
+    expect(cosineSimilarity(zero, v)).toBe(0)
+    expect(cosineSimilarity(v, zero)).toBe(0)
+  })
+
+  it('returns -1 for opposite vectors', () => {
+    const a = [1, 0]
+    const b = [-1, 0]
+    expect(cosineSimilarity(a, b)).toBeCloseTo(-1)
+  })
+
+  it('computes a known similarity value', () => {
+    // cos([1,2,3], [4,5,6]) = 32 / (sqrt(14) * sqrt(77)) ≈ 0.9746
+    const a = [1, 2, 3]
+    const b = [4, 5, 6]
+    const expected = 32 / (Math.sqrt(14) * Math.sqrt(77))
+    expect(cosineSimilarity(a, b)).toBeCloseTo(expected)
+  })
+
+  it('is invariant to vector magnitude', () => {
+    const a = [1, 2, 3]
+    const b = [2, 4, 6]
+    expect(cosineSimilarity(a, b)).toBeCloseTo(1)
+  })
+})
+
+describe('findRelatedPosts', () => {
+  function makePost(slug: string, vector: number[]): PostEmbedding {
+    return { slug, vector }
+  }
+
+  it('excludes the post itself from its related posts', () => {
+    const posts = [makePost('a', [1, 0]), makePost('b', [1, 0])]
+
+    const result = findRelatedPosts(posts)
+
+    expect(result.a.every((r) => r.slug !== 'a')).toBe(true)
+  })
+
+  it('returns posts sorted by descending similarity', () => {
+    const posts = [
+      makePost('target', [1, 0, 0]),
+      makePost('closest', [0.9, 0.1, 0]),
+      makePost('mid', [0.5, 0.5, 0]),
+      makePost('far', [0, 0, 1]),
+    ]
+
+    const result = findRelatedPosts(posts)
+
+    expect(result.target.map((r) => r.slug)).toEqual(['closest', 'mid', 'far'])
+    expect(result.target[0].score).toBeGreaterThan(result.target[1].score)
+    expect(result.target[1].score).toBeGreaterThan(result.target[2].score)
+  })
+
+  it('limits results to maxRelatedPosts', () => {
+    const posts = [
+      makePost('target', [1, 0]),
+      makePost('a', [0.9, 0.1]),
+      makePost('b', [0.8, 0.2]),
+      makePost('c', [0.7, 0.3]),
+      makePost('d', [0.6, 0.4]),
+    ]
+
+    const result = findRelatedPosts(posts, 2)
+
+    expect(result.target).toHaveLength(2)
+    expect(result.target[0].slug).toBe('a')
+    expect(result.target[1].slug).toBe('b')
+  })
+
+  it('returns an empty object for empty input', () => {
+    const result = findRelatedPosts([])
+    expect(Object.keys(result)).toHaveLength(0)
+  })
+
+  it('returns an empty related list for a single post', () => {
+    const posts = [makePost('only', [1, 0])]
+    const result = findRelatedPosts(posts)
+    expect(result.only).toEqual([])
+  })
+})

--- a/src/lib/related-posts.test.ts
+++ b/src/lib/related-posts.test.ts
@@ -45,6 +45,14 @@ describe('cosineSimilarity', () => {
     const b = [2, 4, 6]
     expect(cosineSimilarity(a, b)).toBeCloseTo(1)
   })
+
+  it('throws when vectors have different lengths', () => {
+    const a = [1, 2, 3]
+    const b = [1, 2]
+    expect(() => cosineSimilarity(a, b)).toThrow(
+      'Vectors must have the same length (got 3 and 2)',
+    )
+  })
 })
 
 describe('findRelatedPosts', () => {

--- a/src/lib/related-posts.ts
+++ b/src/lib/related-posts.ts
@@ -5,6 +5,12 @@
  * to avoid division by zero.
  */
 export function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length) {
+    throw new Error(
+      `Vectors must have the same length (got ${String(a.length)} and ${String(b.length)})`,
+    )
+  }
+
   let dot = 0
   let normA = 0
   let normB = 0
@@ -32,11 +38,28 @@ export interface PostEmbedding {
   vector: number[]
 }
 
+function computeNorm(vector: number[]): number {
+  let sum = 0
+  for (const v of vector) {
+    sum += v * v
+  }
+  return Math.sqrt(sum)
+}
+
+function dotProduct(a: number[], b: number[]): number {
+  let sum = 0
+  for (let i = 0; i < a.length; i++) {
+    sum += a[i] * b[i]
+  }
+  return sum
+}
+
 /**
  * Find the top-N most similar posts for each post based on cosine similarity.
  *
  * Each post is excluded from its own related list. Results are sorted by
- * descending similarity score.
+ * descending similarity score. Norms are pre-computed to avoid redundant
+ * calculations across pairs.
  */
 export function findRelatedPosts(
   posts: PostEmbedding[],
@@ -44,18 +67,31 @@ export function findRelatedPosts(
 ): Record<string, ScoredSlug[]> {
   const result: Record<string, ScoredSlug[]> = {}
 
+  // Pre-compute norms to avoid recalculating for each pair
+  const norms = new Map<string, number>()
+  for (const post of posts) {
+    norms.set(post.slug, computeNorm(post.vector))
+  }
+
   for (const post of posts) {
     const scores: ScoredSlug[] = []
+    const normA = norms.get(post.slug) ?? 0
 
     for (const other of posts) {
       if (other.slug === post.slug) {
         continue
       }
 
-      scores.push({
-        slug: other.slug,
-        score: cosineSimilarity(post.vector, other.vector),
-      })
+      const normB = norms.get(other.slug) ?? 0
+
+      let score: number
+      if (normA === 0 || normB === 0) {
+        score = 0
+      } else {
+        score = dotProduct(post.vector, other.vector) / (normA * normB)
+      }
+
+      scores.push({ slug: other.slug, score })
     }
 
     scores.sort((a, b) => b.score - a.score)

--- a/src/lib/related-posts.ts
+++ b/src/lib/related-posts.ts
@@ -1,0 +1,67 @@
+/**
+ * Compute cosine similarity between two vectors of equal length.
+ *
+ * Returns 0 when either vector is a zero vector (all components are 0)
+ * to avoid division by zero.
+ */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  let dot = 0
+  let normA = 0
+  let normB = 0
+
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i]
+    normA += a[i] * a[i]
+    normB += b[i] * b[i]
+  }
+
+  if (normA === 0 || normB === 0) {
+    return 0
+  }
+
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB))
+}
+
+export interface ScoredSlug {
+  slug: string
+  score: number
+}
+
+export interface PostEmbedding {
+  slug: string
+  vector: number[]
+}
+
+/**
+ * Find the top-N most similar posts for each post based on cosine similarity.
+ *
+ * Each post is excluded from its own related list. Results are sorted by
+ * descending similarity score.
+ */
+export function findRelatedPosts(
+  posts: PostEmbedding[],
+  maxRelatedPosts: number = 5,
+): Record<string, ScoredSlug[]> {
+  const result: Record<string, ScoredSlug[]> = {}
+
+  for (const post of posts) {
+    const scores: ScoredSlug[] = []
+
+    for (const other of posts) {
+      if (other.slug === post.slug) {
+        continue
+      }
+
+      scores.push({
+        slug: other.slug,
+        score: cosineSimilarity(post.vector, other.vector),
+      })
+    }
+
+    scores.sort((a, b) => b.score - a.score)
+
+    result[post.slug] = scores.slice(0, maxRelatedPosts)
+  }
+
+  return result
+}


### PR DESCRIPTION
## Why

- The related posts recommendation feature requires logic to compute similarity between articles and select the most relevant ones based on embedding vectors

## What

- Add a cosine similarity function and a related posts selection module
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/fohte.net/pull/461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
