### PR TITLE
lib: Add Astro Content Loader for related posts data generation

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -2,6 +2,8 @@ import { glob } from 'astro/loaders'
 import { z } from 'astro/zod'
 import { defineCollection } from 'astro:content'
 
+import { relatedPostsLoader } from '@/lib/related-posts-loader'
+
 const posts = defineCollection({
   loader: glob({ pattern: '**/*.mdx', base: './src/content/posts' }),
   schema: z.object({
@@ -14,4 +16,17 @@ const posts = defineCollection({
   }),
 })
 
-export const collections = { posts }
+const relatedPosts = defineCollection({
+  loader: relatedPostsLoader(),
+  schema: z.object({
+    slug: z.string(),
+    relatedSlugs: z.array(
+      z.object({
+        slug: z.string(),
+        score: z.number(),
+      }),
+    ),
+  }),
+})
+
+export const collections = { posts, relatedPosts }

--- a/src/lib/related-posts-loader.test.ts
+++ b/src/lib/related-posts-loader.test.ts
@@ -12,7 +12,11 @@ import {
   vi,
 } from 'vitest'
 
-import { relatedPostsLoader } from '@/lib/related-posts-loader'
+import {
+  loadRelatedPosts,
+  type Logger,
+  relatedPostsLoader,
+} from '@/lib/related-posts-loader'
 
 // Mock voyage-embeddings to avoid real API calls
 const mockGenerateEmbedding = vi.fn()
@@ -30,61 +34,25 @@ function makeMdxContent(title: string, body: string): string {
   return `---\ntitle: "${title}"\ndate: 2024-01-01\n---\n\n${body}\n`
 }
 
-interface StoreEntry {
-  id: string
-  data: Record<string, unknown>
-  digest?: string
-}
-
-function createMockStore() {
-  const entries = new Map<string, StoreEntry>()
-  const clearFn = vi.fn(() => {
-    entries.clear()
-  })
-  const setFn = vi.fn((entry: StoreEntry) => {
-    entries.set(entry.id, entry)
-    return true
-  })
+function createMockLogger(): Logger & {
+  infoMessages: string[]
+  warnMessages: string[]
+} {
+  const infoMessages: string[] = []
+  const warnMessages: string[] = []
   return {
-    entries,
-    clear: clearFn,
-    set: setFn,
-    get: vi.fn((key: string) => entries.get(key)),
-    has: vi.fn((key: string) => entries.has(key)),
-    delete: vi.fn((key: string) => entries.delete(key)),
-    keys: vi.fn(() => [...entries.keys()]),
-    values: vi.fn(() => [...entries.values()]),
-  }
-}
-
-function createMockContext(store: ReturnType<typeof createMockStore>) {
-  const infoFn = vi.fn()
-  const warnFn = vi.fn()
-  return {
-    context: {
-      store,
-      logger: {
-        info: infoFn,
-        warn: warnFn,
-        error: vi.fn(),
-        debug: vi.fn(),
-        label: 'related-posts-loader',
-        fork: vi.fn(),
-      },
-      parseData: vi.fn(({ data }: { id: string; data: unknown }) =>
-        Promise.resolve(data),
-      ),
-      generateDigest: vi.fn((data: unknown) => JSON.stringify(data)),
-      meta: {},
-      config: {},
-      collection: 'relatedPosts',
+    infoMessages,
+    warnMessages,
+    info: (msg: string) => {
+      infoMessages.push(msg)
     },
-    infoFn,
-    warnFn,
+    warn: (msg: string) => {
+      warnMessages.push(msg)
+    },
   }
 }
 
-describe('relatedPostsLoader', () => {
+describe('loadRelatedPosts', () => {
   let tmpDir: string
   let postsDir: string
   let embeddingsDir: string
@@ -105,7 +73,7 @@ describe('relatedPostsLoader', () => {
     await rm(tmpDir, { recursive: true, force: true })
   })
 
-  it('loads posts and stores related post data correctly', async () => {
+  it('loads posts and returns related post data correctly', async () => {
     // Create 3 test MDX files
     await writeFile(
       path.join(postsDir, 'post-a.mdx'),
@@ -126,37 +94,27 @@ describe('relatedPostsLoader', () => {
       .mockResolvedValueOnce({ vector: makeVector(2), totalTokens: 10 })
       .mockResolvedValueOnce({ vector: makeVector(3), totalTokens: 10 })
 
-    const loader = relatedPostsLoader({
-      postsDir,
-      embeddingsDir,
-      maxRelatedPosts: 2,
-    })
+    const logger = createMockLogger()
+    const result = await loadRelatedPosts(
+      { postsDir, embeddingsDir, maxRelatedPosts: 2 },
+      logger,
+    )
 
-    const store = createMockStore()
-    const { context, infoFn } = createMockContext(store)
+    // Verify result structure
+    expect(result.totalPosts).toBe(3)
+    expect(result.apiCalls).toBe(3)
+    expect(result.cacheHits).toBe(0)
+    expect(result.skippedPosts).toBe(0)
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- mock context
-    await loader.load(context as never)
-
-    // Verify store was populated
-    expect(store.clear).toHaveBeenCalled()
-    expect(store.set).toHaveBeenCalledTimes(3)
-
-    // Verify each entry has the correct structure
+    // Verify each post has related posts
     for (const slug of ['post-a', 'post-b', 'post-c']) {
-      const entry = store.entries.get(slug)
-      expect(entry).toBeDefined()
-      expect(entry?.data).toHaveProperty('slug', slug)
-      const relatedSlugs = entry?.data.relatedSlugs
-      expect(relatedSlugs).toHaveLength(2)
-      expect(Array.isArray(relatedSlugs)).toBe(true)
-      if (Array.isArray(relatedSlugs)) {
-        for (const related of relatedSlugs) {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- dynamic test data
-          expect(related.slug).not.toBe(slug)
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- dynamic test data
-          expect(typeof related.score).toBe('number')
-        }
+      const related = result.relatedPostsMap[slug]
+      expect(related).toBeDefined()
+      expect(related).toHaveLength(2)
+      // Each related slug should not be the post itself
+      for (const entry of related) {
+        expect(entry.slug).not.toBe(slug)
+        expect(typeof entry.score).toBe('number')
       }
     }
 
@@ -164,9 +122,9 @@ describe('relatedPostsLoader', () => {
     expect(mockGenerateEmbedding).toHaveBeenCalledTimes(3)
 
     // Verify logger output
-    expect(infoFn).toHaveBeenCalledWith(expect.stringContaining('3 MDX files'))
-    expect(infoFn).toHaveBeenCalledWith(expect.stringContaining('0 cache hits'))
-    expect(infoFn).toHaveBeenCalledWith(expect.stringContaining('3 API calls'))
+    expect(logger.infoMessages.some((m) => m.includes('3 MDX files'))).toBe(
+      true,
+    )
   })
 
   it('uses cache on second run and only regenerates changed posts', async () => {
@@ -180,26 +138,19 @@ describe('relatedPostsLoader', () => {
       makeMdxContent('Post Y', 'Original content for Y'),
     )
 
-    const vectorX = makeVector(10)
-    const vectorY = makeVector(20)
-
     mockGenerateEmbedding
-      .mockResolvedValueOnce({ vector: vectorX, totalTokens: 10 })
-      .mockResolvedValueOnce({ vector: vectorY, totalTokens: 10 })
+      .mockResolvedValueOnce({ vector: makeVector(10), totalTokens: 10 })
+      .mockResolvedValueOnce({ vector: makeVector(20), totalTokens: 10 })
 
-    const loader = relatedPostsLoader({
-      postsDir,
-      embeddingsDir,
-      maxRelatedPosts: 1,
-    })
-
-    const store1 = createMockStore()
-    const { context: context1 } = createMockContext(store1)
+    const logger1 = createMockLogger()
 
     // First run: all API calls
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- mock context
-    await loader.load(context1 as never)
-    expect(mockGenerateEmbedding).toHaveBeenCalledTimes(2)
+    const result1 = await loadRelatedPosts(
+      { postsDir, embeddingsDir, maxRelatedPosts: 1 },
+      logger1,
+    )
+    expect(result1.apiCalls).toBe(2)
+    expect(result1.cacheHits).toBe(0)
 
     // Reset mock
     mockGenerateEmbedding.mockReset()
@@ -210,27 +161,23 @@ describe('relatedPostsLoader', () => {
       makeMdxContent('Post X', 'Updated content for X'),
     )
 
-    const newVectorX = makeVector(30)
     mockGenerateEmbedding.mockResolvedValueOnce({
-      vector: newVectorX,
+      vector: makeVector(30),
       totalTokens: 10,
     })
 
-    const store2 = createMockStore()
-    const { context: context2, infoFn: infoFn2 } = createMockContext(store2)
+    const logger2 = createMockLogger()
 
     // Second run: only post-x should trigger API call
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- mock context
-    await loader.load(context2 as never)
+    const result2 = await loadRelatedPosts(
+      { postsDir, embeddingsDir, maxRelatedPosts: 1 },
+      logger2,
+    )
 
     // Only 1 API call (post-x changed, post-y cache hit)
+    expect(result2.apiCalls).toBe(1)
+    expect(result2.cacheHits).toBe(1)
     expect(mockGenerateEmbedding).toHaveBeenCalledTimes(1)
-
-    // Verify logging shows 1 cache hit and 1 API call
-    expect(infoFn2).toHaveBeenCalledWith(
-      expect.stringContaining('1 cache hits'),
-    )
-    expect(infoFn2).toHaveBeenCalledWith(expect.stringContaining('1 API calls'))
   })
 
   it('only processes .mdx files', async () => {
@@ -246,49 +193,38 @@ describe('relatedPostsLoader', () => {
       totalTokens: 10,
     })
 
-    const loader = relatedPostsLoader({ postsDir, embeddingsDir })
-    const store = createMockStore()
-    const { context } = createMockContext(store)
+    const logger = createMockLogger()
+    const result = await loadRelatedPosts(
+      { postsDir, embeddingsDir, maxRelatedPosts: 5 },
+      logger,
+    )
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- mock context
-    await loader.load(context as never)
-
-    expect(store.set).toHaveBeenCalledTimes(1)
+    expect(result.totalPosts).toBe(1)
     expect(mockGenerateEmbedding).toHaveBeenCalledTimes(1)
   })
 
   it('uses default maxRelatedPosts of 5', async () => {
     // Create 7 posts
-    const vectors: number[][] = []
     for (let i = 0; i < 7; i++) {
       await writeFile(
         path.join(postsDir, `post-${String(i)}.mdx`),
         makeMdxContent(`Post ${String(i)}`, `Content ${String(i)}`),
       )
-      vectors.push(makeVector(i * 10))
-    }
-
-    for (const v of vectors) {
       mockGenerateEmbedding.mockResolvedValueOnce({
-        vector: v,
+        vector: makeVector(i * 10),
         totalTokens: 10,
       })
     }
 
-    const loader = relatedPostsLoader({ postsDir, embeddingsDir })
-    const store = createMockStore()
-    const { context } = createMockContext(store)
+    const logger = createMockLogger()
+    const result = await loadRelatedPosts(
+      { postsDir, embeddingsDir, maxRelatedPosts: 5 },
+      logger,
+    )
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- mock context
-    await loader.load(context as never)
-
-    // Each post should have at most 5 related posts
-    for (const [, entry] of store.entries) {
-      const relatedSlugs = entry.data.relatedSlugs
-      expect(Array.isArray(relatedSlugs)).toBe(true)
-      if (Array.isArray(relatedSlugs)) {
-        expect(relatedSlugs.length).toBeLessThanOrEqual(5)
-      }
+    // Each post should have at most 5 related posts (6 others, capped at 5)
+    for (const related of Object.values(result.relatedPostsMap)) {
+      expect(related.length).toBeLessThanOrEqual(5)
     }
   })
 
@@ -300,23 +236,29 @@ describe('relatedPostsLoader', () => {
 
     mockGenerateEmbedding.mockResolvedValueOnce(null)
 
-    const loader = relatedPostsLoader({ postsDir, embeddingsDir })
-    const store = createMockStore()
-    const { context, warnFn, infoFn } = createMockContext(store)
-
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- mock context
-    await loader.load(context as never)
-
-    // Post should be skipped, store should be empty
-    expect(store.set).not.toHaveBeenCalled()
-    expect(warnFn).toHaveBeenCalledWith(
-      expect.stringContaining('API key not configured'),
+    const logger = createMockLogger()
+    const result = await loadRelatedPosts(
+      { postsDir, embeddingsDir, maxRelatedPosts: 5 },
+      logger,
     )
-    expect(infoFn).toHaveBeenCalledWith(expect.stringContaining('1 skipped'))
-  })
 
+    // Post should be skipped
+    expect(result.totalPosts).toBe(0)
+    expect(result.skippedPosts).toBe(1)
+    expect(
+      logger.warnMessages.some((m) => m.includes('API key not configured')),
+    ).toBe(true)
+  })
+})
+
+describe('relatedPostsLoader', () => {
   it('returns the correct loader name', () => {
     const loader = relatedPostsLoader()
     expect(loader.name).toBe('related-posts-loader')
+  })
+
+  it('exposes the schema', () => {
+    const loader = relatedPostsLoader()
+    expect(loader).toHaveProperty('schema')
   })
 })

--- a/src/lib/related-posts-loader.test.ts
+++ b/src/lib/related-posts-loader.test.ts
@@ -1,0 +1,322 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest'
+
+import { relatedPostsLoader } from '@/lib/related-posts-loader'
+
+// Mock voyage-embeddings to avoid real API calls
+const mockGenerateEmbedding = vi.fn()
+
+vi.mock('@/lib/voyage-embeddings', () => ({
+  generateEmbedding: (...args: unknown[]) =>
+    mockGenerateEmbedding(...args) as unknown,
+}))
+
+function makeVector(seed: number, dimensions: number = 1024): number[] {
+  return Array.from({ length: dimensions }, (_, i) => Math.sin(seed + i))
+}
+
+function makeMdxContent(title: string, body: string): string {
+  return `---\ntitle: "${title}"\ndate: 2024-01-01\n---\n\n${body}\n`
+}
+
+interface StoreEntry {
+  id: string
+  data: Record<string, unknown>
+  digest?: string
+}
+
+function createMockStore() {
+  const entries = new Map<string, StoreEntry>()
+  const clearFn = vi.fn(() => {
+    entries.clear()
+  })
+  const setFn = vi.fn((entry: StoreEntry) => {
+    entries.set(entry.id, entry)
+    return true
+  })
+  return {
+    entries,
+    clear: clearFn,
+    set: setFn,
+    get: vi.fn((key: string) => entries.get(key)),
+    has: vi.fn((key: string) => entries.has(key)),
+    delete: vi.fn((key: string) => entries.delete(key)),
+    keys: vi.fn(() => [...entries.keys()]),
+    values: vi.fn(() => [...entries.values()]),
+  }
+}
+
+function createMockContext(store: ReturnType<typeof createMockStore>) {
+  const infoFn = vi.fn()
+  const warnFn = vi.fn()
+  return {
+    context: {
+      store,
+      logger: {
+        info: infoFn,
+        warn: warnFn,
+        error: vi.fn(),
+        debug: vi.fn(),
+        label: 'related-posts-loader',
+        fork: vi.fn(),
+      },
+      parseData: vi.fn(({ data }: { id: string; data: unknown }) =>
+        Promise.resolve(data),
+      ),
+      generateDigest: vi.fn((data: unknown) => JSON.stringify(data)),
+      meta: {},
+      config: {},
+      collection: 'relatedPosts',
+    },
+    infoFn,
+    warnFn,
+  }
+}
+
+describe('relatedPostsLoader', () => {
+  let tmpDir: string
+  let postsDir: string
+  let embeddingsDir: string
+  let warnSpy: MockInstance
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), 'related-posts-loader-test-'))
+    postsDir = path.join(tmpDir, 'posts')
+    embeddingsDir = path.join(tmpDir, 'embeddings')
+    await mkdir(postsDir, { recursive: true })
+
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockGenerateEmbedding.mockReset()
+  })
+
+  afterEach(async () => {
+    warnSpy.mockRestore()
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('loads posts and stores related post data correctly', async () => {
+    // Create 3 test MDX files
+    await writeFile(
+      path.join(postsDir, 'post-a.mdx'),
+      makeMdxContent('Post A', 'Content about TypeScript and React'),
+    )
+    await writeFile(
+      path.join(postsDir, 'post-b.mdx'),
+      makeMdxContent('Post B', 'Content about TypeScript and Node'),
+    )
+    await writeFile(
+      path.join(postsDir, 'post-c.mdx'),
+      makeMdxContent('Post C', 'Content about cooking recipes'),
+    )
+
+    // Mock embedding generation
+    mockGenerateEmbedding
+      .mockResolvedValueOnce({ vector: makeVector(1), totalTokens: 10 })
+      .mockResolvedValueOnce({ vector: makeVector(2), totalTokens: 10 })
+      .mockResolvedValueOnce({ vector: makeVector(3), totalTokens: 10 })
+
+    const loader = relatedPostsLoader({
+      postsDir,
+      embeddingsDir,
+      maxRelatedPosts: 2,
+    })
+
+    const store = createMockStore()
+    const { context, infoFn } = createMockContext(store)
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- mock context
+    await loader.load(context as never)
+
+    // Verify store was populated
+    expect(store.clear).toHaveBeenCalled()
+    expect(store.set).toHaveBeenCalledTimes(3)
+
+    // Verify each entry has the correct structure
+    for (const slug of ['post-a', 'post-b', 'post-c']) {
+      const entry = store.entries.get(slug)
+      expect(entry).toBeDefined()
+      expect(entry?.data).toHaveProperty('slug', slug)
+      const relatedSlugs = entry?.data.relatedSlugs
+      expect(relatedSlugs).toHaveLength(2)
+      expect(Array.isArray(relatedSlugs)).toBe(true)
+      if (Array.isArray(relatedSlugs)) {
+        for (const related of relatedSlugs) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- dynamic test data
+          expect(related.slug).not.toBe(slug)
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- dynamic test data
+          expect(typeof related.score).toBe('number')
+        }
+      }
+    }
+
+    // Verify API was called 3 times (no cache)
+    expect(mockGenerateEmbedding).toHaveBeenCalledTimes(3)
+
+    // Verify logger output
+    expect(infoFn).toHaveBeenCalledWith(expect.stringContaining('3 MDX files'))
+    expect(infoFn).toHaveBeenCalledWith(expect.stringContaining('0 cache hits'))
+    expect(infoFn).toHaveBeenCalledWith(expect.stringContaining('3 API calls'))
+  })
+
+  it('uses cache on second run and only regenerates changed posts', async () => {
+    // Create 2 test MDX files
+    await writeFile(
+      path.join(postsDir, 'post-x.mdx'),
+      makeMdxContent('Post X', 'Original content for X'),
+    )
+    await writeFile(
+      path.join(postsDir, 'post-y.mdx'),
+      makeMdxContent('Post Y', 'Original content for Y'),
+    )
+
+    const vectorX = makeVector(10)
+    const vectorY = makeVector(20)
+
+    mockGenerateEmbedding
+      .mockResolvedValueOnce({ vector: vectorX, totalTokens: 10 })
+      .mockResolvedValueOnce({ vector: vectorY, totalTokens: 10 })
+
+    const loader = relatedPostsLoader({
+      postsDir,
+      embeddingsDir,
+      maxRelatedPosts: 1,
+    })
+
+    const store1 = createMockStore()
+    const { context: context1 } = createMockContext(store1)
+
+    // First run: all API calls
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-type-assertion -- mock context
+    await loader.load(context1 as never)
+    expect(mockGenerateEmbedding).toHaveBeenCalledTimes(2)
+
+    // Reset mock
+    mockGenerateEmbedding.mockReset()
+
+    // Modify only post-x
+    await writeFile(
+      path.join(postsDir, 'post-x.mdx'),
+      makeMdxContent('Post X', 'Updated content for X'),
+    )
+
+    const newVectorX = makeVector(30)
+    mockGenerateEmbedding.mockResolvedValueOnce({
+      vector: newVectorX,
+      totalTokens: 10,
+    })
+
+    const store2 = createMockStore()
+    const { context: context2, infoFn: infoFn2 } = createMockContext(store2)
+
+    // Second run: only post-x should trigger API call
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-type-assertion -- mock context
+    await loader.load(context2 as never)
+
+    // Only 1 API call (post-x changed, post-y cache hit)
+    expect(mockGenerateEmbedding).toHaveBeenCalledTimes(1)
+
+    // Verify logging shows 1 cache hit and 1 API call
+    expect(infoFn2).toHaveBeenCalledWith(
+      expect.stringContaining('1 cache hits'),
+    )
+    expect(infoFn2).toHaveBeenCalledWith(expect.stringContaining('1 API calls'))
+  })
+
+  it('only processes .mdx files', async () => {
+    await writeFile(
+      path.join(postsDir, 'post.mdx'),
+      makeMdxContent('Post', 'Content'),
+    )
+    await writeFile(path.join(postsDir, 'readme.md'), '# Readme')
+    await writeFile(path.join(postsDir, 'data.json'), '{}')
+
+    mockGenerateEmbedding.mockResolvedValueOnce({
+      vector: makeVector(1),
+      totalTokens: 10,
+    })
+
+    const loader = relatedPostsLoader({ postsDir, embeddingsDir })
+    const store = createMockStore()
+    const { context } = createMockContext(store)
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- mock context
+    await loader.load(context as never)
+
+    expect(store.set).toHaveBeenCalledTimes(1)
+    expect(mockGenerateEmbedding).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses default maxRelatedPosts of 5', async () => {
+    // Create 7 posts
+    const vectors: number[][] = []
+    for (let i = 0; i < 7; i++) {
+      await writeFile(
+        path.join(postsDir, `post-${String(i)}.mdx`),
+        makeMdxContent(`Post ${String(i)}`, `Content ${String(i)}`),
+      )
+      vectors.push(makeVector(i * 10))
+    }
+
+    for (const v of vectors) {
+      mockGenerateEmbedding.mockResolvedValueOnce({
+        vector: v,
+        totalTokens: 10,
+      })
+    }
+
+    const loader = relatedPostsLoader({ postsDir, embeddingsDir })
+    const store = createMockStore()
+    const { context } = createMockContext(store)
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- mock context
+    await loader.load(context as never)
+
+    // Each post should have at most 5 related posts
+    for (const [, entry] of store.entries) {
+      const relatedSlugs = entry.data.relatedSlugs
+      expect(Array.isArray(relatedSlugs)).toBe(true)
+      if (Array.isArray(relatedSlugs)) {
+        expect(relatedSlugs.length).toBeLessThanOrEqual(5)
+      }
+    }
+  })
+
+  it('skips posts gracefully when API key is not configured', async () => {
+    await writeFile(
+      path.join(postsDir, 'post.mdx'),
+      makeMdxContent('Post', 'Content'),
+    )
+
+    mockGenerateEmbedding.mockResolvedValueOnce(null)
+
+    const loader = relatedPostsLoader({ postsDir, embeddingsDir })
+    const store = createMockStore()
+    const { context, warnFn, infoFn } = createMockContext(store)
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- mock context
+    await loader.load(context as never)
+
+    // Post should be skipped, store should be empty
+    expect(store.set).not.toHaveBeenCalled()
+    expect(warnFn).toHaveBeenCalledWith(
+      expect.stringContaining('API key not configured'),
+    )
+    expect(infoFn).toHaveBeenCalledWith(expect.stringContaining('1 skipped'))
+  })
+
+  it('returns the correct loader name', () => {
+    const loader = relatedPostsLoader()
+    expect(loader.name).toBe('related-posts-loader')
+  })
+})

--- a/src/lib/related-posts-loader.test.ts
+++ b/src/lib/related-posts-loader.test.ts
@@ -197,7 +197,7 @@ describe('relatedPostsLoader', () => {
     const { context: context1 } = createMockContext(store1)
 
     // First run: all API calls
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-type-assertion -- mock context
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- mock context
     await loader.load(context1 as never)
     expect(mockGenerateEmbedding).toHaveBeenCalledTimes(2)
 
@@ -220,7 +220,7 @@ describe('relatedPostsLoader', () => {
     const { context: context2, infoFn: infoFn2 } = createMockContext(store2)
 
     // Second run: only post-x should trigger API call
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-type-assertion -- mock context
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- mock context
     await loader.load(context2 as never)
 
     // Only 1 API call (post-x changed, post-y cache hit)

--- a/src/lib/related-posts-loader.test.ts
+++ b/src/lib/related-posts-loader.test.ts
@@ -228,6 +228,21 @@ describe('loadRelatedPosts', () => {
     }
   })
 
+  it('throws when MDX files exist in subdirectories', async () => {
+    const subDir = path.join(postsDir, 'blog')
+    await mkdir(subDir, { recursive: true })
+    await writeFile(
+      path.join(subDir, 'nested-post.mdx'),
+      makeMdxContent('Nested', 'Content'),
+    )
+
+    const logger = createMockLogger()
+
+    await expect(
+      loadRelatedPosts({ postsDir, embeddingsDir, maxRelatedPosts: 5 }, logger),
+    ).rejects.toThrow('only supports a flat directory structure')
+  })
+
   it('skips posts gracefully when API key is not configured', async () => {
     await writeFile(
       path.join(postsDir, 'post.mdx'),

--- a/src/lib/related-posts-loader.ts
+++ b/src/lib/related-posts-loader.ts
@@ -1,0 +1,132 @@
+import { readdir } from 'node:fs/promises'
+import path from 'node:path'
+
+import type { Loader } from 'astro/loaders'
+import { z } from 'astro/zod'
+
+import { getOrCreateEmbedding } from '@/lib/embedding-cache'
+import { EMBEDDING_MODEL } from '@/lib/embedding-constants'
+import {
+  computeContentHash,
+  extractTextFromFile,
+} from '@/lib/mdx-text-extractor'
+import { findRelatedPosts, type PostEmbedding } from '@/lib/related-posts'
+
+export interface RelatedPostsLoaderOptions {
+  maxRelatedPosts?: number
+  postsDir?: string
+  embeddingsDir?: string
+}
+
+export const relatedPostsSchema = z.object({
+  slug: z.string(),
+  relatedSlugs: z.array(
+    z.object({
+      slug: z.string(),
+      score: z.number(),
+    }),
+  ),
+})
+
+export function relatedPostsLoader(
+  options?: RelatedPostsLoaderOptions,
+): Loader {
+  const maxRelatedPosts = options?.maxRelatedPosts ?? 5
+  const postsDir = options?.postsDir ?? './src/content/posts'
+  const embeddingsDir = options?.embeddingsDir
+
+  return {
+    name: 'related-posts-loader',
+    load: async (context) => {
+      const { store, logger } = context
+      const startTime = performance.now()
+
+      // Read MDX files directly from filesystem (loader execution order is not guaranteed)
+      const resolvedPostsDir = path.resolve(postsDir)
+      const files = await readdir(resolvedPostsDir)
+      const mdxFiles = files.filter((f) => f.endsWith('.mdx'))
+
+      logger.info(`Found ${String(mdxFiles.length)} MDX files`)
+
+      // Extract text and compute embeddings for each post
+      const postEmbeddings: PostEmbedding[] = []
+      let cacheHits = 0
+      let apiCalls = 0
+      let skippedPosts = 0
+
+      for (const file of mdxFiles) {
+        const slug = path.basename(file, '.mdx')
+        const filePath = path.join(resolvedPostsDir, file)
+
+        const extracted = await extractTextFromFile(filePath)
+        const text = `${extracted.title}\n\n${extracted.body}`
+        const cacheKey = computeContentHash(text, EMBEDDING_MODEL)
+
+        // Track whether generate callback was invoked (cache miss)
+        const callTracker = { called: false }
+        let vector: number[]
+        try {
+          vector = await getOrCreateEmbedding(
+            slug,
+            cacheKey,
+            async () => {
+              callTracker.called = true
+              // Dynamic import to avoid voyageai SDK resolution at astro sync time
+              const { generateEmbedding } =
+                await import('@/lib/voyage-embeddings')
+              const result = await generateEmbedding(text)
+              if (result == null) {
+                throw new Error(
+                  `Failed to generate embedding for "${slug}": API key not configured`,
+                )
+              }
+              return result.vector
+            },
+            embeddingsDir,
+          )
+        } catch (error) {
+          // Graceful degradation: skip posts that fail embedding generation
+          logger.warn(
+            `Skipping "${slug}": ${error instanceof Error ? error.message : String(error)}`,
+          )
+          skippedPosts++
+          continue
+        }
+
+        if (callTracker.called) {
+          apiCalls++
+        } else {
+          cacheHits++
+        }
+
+        postEmbeddings.push({ slug, vector })
+      }
+
+      // Compute related posts via cosine similarity
+      const relatedPostsMap = findRelatedPosts(postEmbeddings, maxRelatedPosts)
+
+      // Store results in Content Store
+      store.clear()
+      for (const [slug, relatedSlugs] of Object.entries(relatedPostsMap)) {
+        const rawData = { slug, relatedSlugs }
+        const data = await context.parseData({ id: slug, data: rawData })
+        const digest = context.generateDigest(data)
+        store.set({ id: slug, data, digest })
+      }
+
+      const elapsed = performance.now() - startTime
+      const parts = [
+        `${String(postEmbeddings.length)} posts processed`,
+        `${String(cacheHits)} cache hits`,
+        `${String(apiCalls)} API calls`,
+      ]
+      if (skippedPosts > 0) {
+        parts.push(`${String(skippedPosts)} skipped`)
+      }
+      logger.info(
+        `Completed in ${String(Math.round(elapsed))}ms: ${parts.join(', ')}`,
+      )
+    },
+    schema: relatedPostsSchema,
+  }
+}

--- a/src/lib/related-posts-loader.ts
+++ b/src/lib/related-posts-loader.ts
@@ -60,7 +60,7 @@ export async function loadRelatedPosts(
 ): Promise<LoadResult> {
   const startTime = performance.now()
 
-  // Read MDX files directly from filesystem (loader execution order is not guaranteed)
+  // Read MDX files from filesystem (loader execution order is not guaranteed)
   const resolvedPostsDir = path.resolve(options.postsDir)
   const files = await readdir(resolvedPostsDir)
   const mdxFiles = files.filter((f) => f.endsWith('.mdx'))

--- a/src/lib/related-posts-loader.ts
+++ b/src/lib/related-posts-loader.ts
@@ -10,7 +10,11 @@ import {
   computeContentHash,
   extractTextFromFile,
 } from '@/lib/mdx-text-extractor'
-import { findRelatedPosts, type PostEmbedding } from '@/lib/related-posts'
+import {
+  findRelatedPosts,
+  type PostEmbedding,
+  type ScoredSlug,
+} from '@/lib/related-posts'
 
 export interface RelatedPostsLoaderOptions {
   maxRelatedPosts?: number
@@ -28,6 +32,112 @@ export const relatedPostsSchema = z.object({
   ),
 })
 
+export interface LoadResult {
+  relatedPostsMap: Record<string, ScoredSlug[]>
+  totalPosts: number
+  cacheHits: number
+  apiCalls: number
+  skippedPosts: number
+  elapsedMs: number
+}
+
+export interface Logger {
+  info: (message: string) => void
+  warn: (message: string) => void
+}
+
+/**
+ * Core logic for loading related posts data.
+ * Extracted from the Astro loader for testability.
+ */
+export async function loadRelatedPosts(
+  options: {
+    postsDir: string
+    embeddingsDir?: string
+    maxRelatedPosts: number
+  },
+  logger: Logger,
+): Promise<LoadResult> {
+  const startTime = performance.now()
+
+  // Read MDX files directly from filesystem (loader execution order is not guaranteed)
+  const resolvedPostsDir = path.resolve(options.postsDir)
+  const files = await readdir(resolvedPostsDir)
+  const mdxFiles = files.filter((f) => f.endsWith('.mdx'))
+
+  logger.info(`Found ${String(mdxFiles.length)} MDX files`)
+
+  // Extract text and compute embeddings for each post
+  const postEmbeddings: PostEmbedding[] = []
+  let cacheHits = 0
+  let apiCalls = 0
+  let skippedPosts = 0
+
+  for (const file of mdxFiles) {
+    const slug = path.basename(file, '.mdx')
+    const filePath = path.join(resolvedPostsDir, file)
+
+    const extracted = await extractTextFromFile(filePath)
+    const text = `${extracted.title}\n\n${extracted.body}`
+    const cacheKey = computeContentHash(text, EMBEDDING_MODEL)
+
+    // Track whether generate callback was invoked (cache miss)
+    const callTracker = { called: false }
+    let vector: number[]
+    try {
+      vector = await getOrCreateEmbedding(
+        slug,
+        cacheKey,
+        async () => {
+          callTracker.called = true
+          // Dynamic import to avoid voyageai SDK resolution at astro sync time
+          const { generateEmbedding } = await import('@/lib/voyage-embeddings')
+          const result = await generateEmbedding(text)
+          if (result == null) {
+            throw new Error(
+              `Failed to generate embedding for "${slug}": API key not configured`,
+            )
+          }
+          return result.vector
+        },
+        options.embeddingsDir,
+      )
+    } catch (error) {
+      // Graceful degradation: skip posts that fail embedding generation
+      logger.warn(
+        `Skipping "${slug}": ${error instanceof Error ? error.message : String(error)}`,
+      )
+      skippedPosts++
+      continue
+    }
+
+    if (callTracker.called) {
+      apiCalls++
+    } else {
+      cacheHits++
+    }
+
+    postEmbeddings.push({ slug, vector })
+  }
+
+  // Compute related posts via cosine similarity
+  const relatedPostsMap = findRelatedPosts(
+    postEmbeddings,
+    options.maxRelatedPosts,
+  )
+
+  const elapsedMs = Math.round(performance.now() - startTime)
+
+  return {
+    relatedPostsMap,
+    totalPosts: postEmbeddings.length,
+    cacheHits,
+    apiCalls,
+    skippedPosts,
+    elapsedMs,
+  }
+}
+
 export function relatedPostsLoader(
   options?: RelatedPostsLoaderOptions,
 ): Loader {
@@ -39,92 +149,33 @@ export function relatedPostsLoader(
     name: 'related-posts-loader',
     load: async (context) => {
       const { store, logger } = context
-      const startTime = performance.now()
 
-      // Read MDX files directly from filesystem (loader execution order is not guaranteed)
-      const resolvedPostsDir = path.resolve(postsDir)
-      const files = await readdir(resolvedPostsDir)
-      const mdxFiles = files.filter((f) => f.endsWith('.mdx'))
-
-      logger.info(`Found ${String(mdxFiles.length)} MDX files`)
-
-      // Extract text and compute embeddings for each post
-      const postEmbeddings: PostEmbedding[] = []
-      let cacheHits = 0
-      let apiCalls = 0
-      let skippedPosts = 0
-
-      for (const file of mdxFiles) {
-        const slug = path.basename(file, '.mdx')
-        const filePath = path.join(resolvedPostsDir, file)
-
-        const extracted = await extractTextFromFile(filePath)
-        const text = `${extracted.title}\n\n${extracted.body}`
-        const cacheKey = computeContentHash(text, EMBEDDING_MODEL)
-
-        // Track whether generate callback was invoked (cache miss)
-        const callTracker = { called: false }
-        let vector: number[]
-        try {
-          vector = await getOrCreateEmbedding(
-            slug,
-            cacheKey,
-            async () => {
-              callTracker.called = true
-              // Dynamic import to avoid voyageai SDK resolution at astro sync time
-              const { generateEmbedding } =
-                await import('@/lib/voyage-embeddings')
-              const result = await generateEmbedding(text)
-              if (result == null) {
-                throw new Error(
-                  `Failed to generate embedding for "${slug}": API key not configured`,
-                )
-              }
-              return result.vector
-            },
-            embeddingsDir,
-          )
-        } catch (error) {
-          // Graceful degradation: skip posts that fail embedding generation
-          logger.warn(
-            `Skipping "${slug}": ${error instanceof Error ? error.message : String(error)}`,
-          )
-          skippedPosts++
-          continue
-        }
-
-        if (callTracker.called) {
-          apiCalls++
-        } else {
-          cacheHits++
-        }
-
-        postEmbeddings.push({ slug, vector })
-      }
-
-      // Compute related posts via cosine similarity
-      const relatedPostsMap = findRelatedPosts(postEmbeddings, maxRelatedPosts)
+      const result = await loadRelatedPosts(
+        { postsDir, embeddingsDir, maxRelatedPosts },
+        logger,
+      )
 
       // Store results in Content Store
       store.clear()
-      for (const [slug, relatedSlugs] of Object.entries(relatedPostsMap)) {
+      for (const [slug, relatedSlugs] of Object.entries(
+        result.relatedPostsMap,
+      )) {
         const rawData = { slug, relatedSlugs }
         const data = await context.parseData({ id: slug, data: rawData })
         const digest = context.generateDigest(data)
         store.set({ id: slug, data, digest })
       }
 
-      const elapsed = performance.now() - startTime
       const parts = [
-        `${String(postEmbeddings.length)} posts processed`,
-        `${String(cacheHits)} cache hits`,
-        `${String(apiCalls)} API calls`,
+        `${String(result.totalPosts)} posts processed`,
+        `${String(result.cacheHits)} cache hits`,
+        `${String(result.apiCalls)} API calls`,
       ]
-      if (skippedPosts > 0) {
-        parts.push(`${String(skippedPosts)} skipped`)
+      if (result.skippedPosts > 0) {
+        parts.push(`${String(result.skippedPosts)} skipped`)
       }
       logger.info(
-        `Completed in ${String(Math.round(elapsed))}ms: ${parts.join(', ')}`,
+        `Completed in ${String(result.elapsedMs)}ms: ${parts.join(', ')}`,
       )
     },
     schema: relatedPostsSchema,

--- a/src/lib/related-posts-loader.ts
+++ b/src/lib/related-posts-loader.ts
@@ -1,4 +1,4 @@
-import { readdir } from 'node:fs/promises'
+import { readdir, stat } from 'node:fs/promises'
 import path from 'node:path'
 
 import type { Loader } from 'astro/loaders'
@@ -61,9 +61,30 @@ export async function loadRelatedPosts(
   const startTime = performance.now()
 
   // Read MDX files from filesystem (loader execution order is not guaranteed)
+  // Only flat directory structure is supported — subdirectories require
+  // embedding cache changes to handle slugs with path separators.
   const resolvedPostsDir = path.resolve(options.postsDir)
-  const files = await readdir(resolvedPostsDir)
-  const mdxFiles = files.filter((f) => f.endsWith('.mdx'))
+  const entries = await readdir(resolvedPostsDir)
+
+  // Fail loudly if subdirectories contain MDX files, so the developer
+  // knows to extend the loader and embedding cache for nested paths.
+  for (const entry of entries) {
+    const entryPath = path.join(resolvedPostsDir, entry)
+    const entryStat = await stat(entryPath)
+    if (entryStat.isDirectory()) {
+      const subFiles = await readdir(entryPath)
+      const hasMdx = subFiles.some((f) => f.endsWith('.mdx'))
+      if (hasMdx) {
+        throw new Error(
+          `MDX files found in subdirectory "${entry}" of postsDir. ` +
+            'The related posts loader only supports a flat directory structure. ' +
+            'To add subdirectory support, update the loader and embedding cache module.',
+        )
+      }
+    }
+  }
+
+  const mdxFiles = entries.filter((f) => f.endsWith('.mdx'))
 
   logger.info(`Found ${String(mdxFiles.length)} MDX files`)
 


### PR DESCRIPTION
## Why

- Integrate previously implemented modules into a unified Astro build-time pipeline to generate embedding-based related post recommendations

## What

- Orchestrate MDX text extraction, Voyage AI API client, embedding cache, and cosine similarity as an Astro Content Collection Custom Loader, making related posts data queryable via `getEntry('relatedPosts', slug)` with full type safety
- Gracefully skip posts on embedding generation failure with a warning, allowing builds to proceed without an API key or during `astro sync`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/fohte.net/pull/463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
