### PR TITLE
ci: issue deploy workflow GitHub App tokens via octo-sts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,13 +10,15 @@ jobs:
       contents: read
       deployments: write
       pull-requests: write
+      id-token: write
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          scope: fohte
+          identity: fohte.net-deploy
+          domain: octo-sts.fohte.net
 
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
## Purpose

- Retire the long-lived `APP_PRIVATE_KEY` Actions secret and consolidate on short-lived GitHub App tokens issued via OIDC

## Approach

- Issue tokens through the self-hosted [octo-sts.fohte.net](https://octo-sts.fohte.net) instance
    - The matching OrgTrustPolicy ([`fohte.net-deploy.sts.yaml`](https://github.com/fohte/.github/blob/82a514e957e0c41fc665de1351bbc92915f21b7b/.github/chainguard/fohte.net-deploy.sts.yaml)) is already in place on the fohte/.github side
