### PR TITLE
ci: pin mise version to 2026.6.6 in mise-action calls

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,7 @@ jobs:
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
         with:
           install: true
+          version: 2026.6.6
 
       - run: corepack enable
 

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -13,6 +13,7 @@ jobs:
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
         with:
           install: true
+          version: 2026.6.6
       - uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f # v1.5.0
 
       - run: corepack enable


### PR DESCRIPTION
## Purpose

- Align the mise version across the org by applying the same pin that generic-boilerplate v0.8.4 ([fohte/generic-boilerplate#428](https://github.com/fohte/generic-boilerplate/pull/428)) added to the template workflows, to the workflows this repository maintains on its own

## Approach

- Pass `version: 2026.6.6` to every `jdx/mise-action` invocation
